### PR TITLE
Django 1.2 multi database support

### DIFF
--- a/src/xmlrunner/extra/djangotestrunner.py
+++ b/src/xmlrunner/extra/djangotestrunner.py
@@ -36,59 +36,57 @@ project's 'settings.py' file:
 from django.test.simple import *
 import xmlrunner
 
+class XMLTestRunner(DjangoTestSuiteRunner):
+    def run_tests(self, test_labels, verbosity=1, interactive=True, extra_tests=[]):
+        """
+        Run the unit tests for all the test labels in the provided list.
+        Labels must be of the form:
+         - app.TestClass.test_method
+            Run a single specific test method
+         - app.TestClass
+            Run all the test methods in a given class
+         - app
+            Search for doctests and unittests in the named application.
 
-def run_tests(test_labels, verbosity=1, interactive=True, extra_tests=[]):
-    """
-    Run the unit tests for all the test labels in the provided list.
-    Labels must be of the form:
-     - app.TestClass.test_method
-        Run a single specific test method
-     - app.TestClass
-        Run all the test methods in a given class
-     - app
-        Search for doctests and unittests in the named application.
-
-    When looking for tests, the test runner will look in the models and
-    tests modules for the application.
-    
-    A list of 'extra' tests may also be provided; these tests
-    will be added to the test suite.
-    
-    Returns the number of tests that failed.
-    """
-    setup_test_environment()
-    
-    settings.DEBUG = False
-    
-    verbose = getattr(settings, 'TEST_OUTPUT_VERBOSE', False)
-    descriptions = getattr(settings, 'TEST_OUTPUT_DESCRIPTIONS', False)
-    output = getattr(settings, 'TEST_OUTPUT_DIR', '.')
-    
-    suite = unittest.TestSuite()
-    
-    if test_labels:
-        for label in test_labels:
-            if '.' in label:
-                suite.addTest(build_test(label))
-            else:
-                app = get_app(label)
+        When looking for tests, the test runner will look in the models and
+        tests modules for the application.
+        
+        A list of 'extra' tests may also be provided; these tests
+        will be added to the test suite.
+        
+        Returns the number of tests that failed.
+        """
+        setup_test_environment()
+        
+        settings.DEBUG = False
+        
+        verbose = getattr(settings, 'TEST_OUTPUT_VERBOSE', False)
+        descriptions = getattr(settings, 'TEST_OUTPUT_DESCRIPTIONS', False)
+        output = getattr(settings, 'TEST_OUTPUT_DIR', '.')
+        
+        suite = unittest.TestSuite()
+        
+        if test_labels:
+            for label in test_labels:
+                if '.' in label:
+                    suite.addTest(build_test(label))
+                else:
+                    app = get_app(label)
+                    suite.addTest(build_suite(app))
+        else:
+            for app in get_apps():
                 suite.addTest(build_suite(app))
-    else:
-        for app in get_apps():
-            suite.addTest(build_suite(app))
-    
-    for test in extra_tests:
-        suite.addTest(test)
+        
+        for test in extra_tests:
+            suite.addTest(test)
 
-    old_name = settings.DATABASE_NAME
-    from django.db import connection
-    connection.creation.create_test_db(verbosity, autoclobber=not interactive)
-    
-    result = xmlrunner.XMLTestRunner(
-        verbose=verbose, descriptions=descriptions, output=output).run(suite)
-    
-    connection.creation.destroy_test_db(old_name, verbosity)
-    
-    teardown_test_environment()
-    
-    return len(result.failures) + len(result.errors)
+        old_config = self.setup_databases()
+
+        result = xmlrunner.XMLTestRunner(
+            verbose=verbose, descriptions=descriptions, output=output).run(suite)
+        
+        self.teardown_databases(old_config)
+
+        teardown_test_environment()
+        
+        return len(result.failures) + len(result.errors)


### PR DESCRIPTION
Hello!
Sorry if I'm doing this wrong. I'm not familiar with git at all.

In django 1.2 the run_test() function was moved to inside of the class DjangoTestSuiteRunner class.
Also, there needs to be a setup_databases() and a teardown_databases().

I don't think this is backwards compatible though.

Here's the documentation. 
http://docs.djangoproject.com/en/dev/topics/testing/?from=olddocs#defining-a-test-runner

Thanks for the awesome test runner!
