### PR TITLE
Fix crash with some non-ascii exceptions

### DIFF
--- a/src/xmlrunner/__init__.py
+++ b/src/xmlrunner/__init__.py
@@ -190,9 +190,9 @@ class _XMLTestResult(_TextTestResult):
             testcase.appendChild(failure)
             
             failure.setAttribute('type', test_result.err[0].__name__)
-            failure.setAttribute('message', str(test_result.err[1]))
+            failure.setAttribute('message', unicode(test_result.err[1]))
             
-            error_info = test_result.get_error_info()
+            error_info = unicode(test_result.get_error_info(), "utf-8")
             failureText = xml_document.createCDATASection(error_info)
             failure.appendChild(failureText)
     
@@ -233,7 +233,7 @@ class _XMLTestResult(_TextTestResult):
             for test in tests:
                 _XMLTestResult._report_testcase(suite, test, testsuite, doc)
             _XMLTestResult._report_output(test_runner, testsuite, doc)
-            xml_content = doc.toprettyxml(indent='\t')
+            xml_content = doc.toprettyxml(indent='\t', encoding="utf-8")
             
             if type(test_runner.output) is str:
                 report_file = file('%s%sTEST-%s.xml' % \

--- a/src/xmlrunner/tests/fixtures/errord_test_case.xml
+++ b/src/xmlrunner/tests/fixtures/errord_test_case.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <testsuite errors="1" failures="0" name="xmlrunner.tests.testsuite_cases.ErrordTestCase" tests="1" time="0.000">
 	<testcase classname="xmlrunner.tests.testsuite_cases.ErrordTestCase" name="test_errord" time="0.000">
 		<error message="unsupported operand type(s) for +: 'NoneType' and 'int'" type="TypeError">

--- a/src/xmlrunner/tests/fixtures/failed_test_case.xml
+++ b/src/xmlrunner/tests/fixtures/failed_test_case.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <testsuite errors="0" failures="1" name="xmlrunner.tests.testsuite_cases.FailedTestCase" tests="1" time="0.000">
 	<testcase classname="xmlrunner.tests.testsuite_cases.FailedTestCase" name="test_failure" time="0.000">
 		<failure message="" type="AssertionError">

--- a/src/xmlrunner/tests/fixtures/mixed_test_case.xml
+++ b/src/xmlrunner/tests/fixtures/mixed_test_case.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <testsuite errors="1" failures="1" name="xmlrunner.tests.testsuite_cases.MixedTestCase" tests="3" time="0.000">
 	<testcase classname="xmlrunner.tests.testsuite_cases.MixedTestCase" name="test_success" time="0.000"/>
 	<testcase classname="xmlrunner.tests.testsuite_cases.MixedTestCase" name="test_failure" time="0.000">

--- a/src/xmlrunner/tests/fixtures/successful_test_case.xml
+++ b/src/xmlrunner/tests/fixtures/successful_test_case.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <testsuite errors="0" failures="0" name="xmlrunner.tests.testsuite_cases.SuccessfulTestCase" tests="1" time="0.000">
 	<testcase classname="xmlrunner.tests.testsuite_cases.SuccessfulTestCase" name="test_success" time="0.000"/>
 	<system-out>

--- a/src/xmlrunner/tests/fixtures/unicode_error_diff.xml
+++ b/src/xmlrunner/tests/fixtures/unicode_error_diff.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<testsuite errors="0" failures="1" name="xmlrunner.tests.testsuite_cases.UnicodeTestSuite" tests="1" time="0.000">
+	<testcase classname="xmlrunner.tests.testsuite_cases.UnicodeTestSuite" name="test_pouet" time="0.000">
+		<failure message="u'caf\xe9' != u'caffe'
+- café
++ caffe
+" type="AssertionError">
+<![CDATA[Traceback (most recent call last):
+  File "{{PATH}}/src/xmlrunner/tests/testsuite_cases.py", line 41, in test_pouet
+    self.assertEqual(u"café", u"caffe")
+AssertionError: u'caf\xe9' != u'caffe'
+- caf\xe9
++ caffe
+
+]]>		</failure>
+	</testcase>
+	<system-out>
+<![CDATA[]]>	</system-out>
+	<system-err>
+<![CDATA[]]>	</system-err>
+</testsuite>

--- a/src/xmlrunner/tests/fixtures/unicode_error_nodiff.xml
+++ b/src/xmlrunner/tests/fixtures/unicode_error_nodiff.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<testsuite errors="0" failures="1" name="xmlrunner.tests.testsuite_cases.UnicodeTestSuite" tests="1" time="0.000">
+	<testcase classname="xmlrunner.tests.testsuite_cases.UnicodeTestSuite" name="test_pouet" time="0.000">
+		<failure message="u'caf\xe9' != u'caffe'" type="AssertionError">
+<![CDATA[Traceback (most recent call last):
+  File "{{PATH}}/src/xmlrunner/tests/testsuite_cases.py", line 41, in test_pouet
+    self.assertEqual(u"café", u"caffe")
+AssertionError: u'caf\xe9' != u'caffe'
+]]>		</failure>
+	</testcase>
+	<system-out>
+<![CDATA[]]>	</system-out>
+	<system-err>
+<![CDATA[]]>	</system-err>
+</testsuite>

--- a/src/xmlrunner/tests/testsuite.py
+++ b/src/xmlrunner/tests/testsuite.py
@@ -73,6 +73,16 @@ class XMLTestRunnerTestCase(unittest.TestCase):
         self._run_test_class(testcases.MixedTestCase, \
             'mixed_test_case')
 
+    def test_unicode_exception_test_case(self):
+        "Check that unicode inside exception does not crash."
+
+        # 2.7+ and 3.2+ unittests module includes a diff with some assertions
+        if hasattr(self, "maxDiff"):
+            expected = 'unicode_error_diff'
+        else:
+            expected = 'unicode_error_nodiff'
+        self._run_test_class(testcases.UnicodeTestSuite, \
+            expected)
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/xmlrunner/tests/testsuite_cases.py
+++ b/src/xmlrunner/tests/testsuite_cases.py
@@ -35,3 +35,7 @@ class MixedTestCase(unittest.TestCase):
     
     def test_errord(self):
         None + 1
+
+class UnicodeTestSuite(unittest.TestCase):
+    def test_pouet(self):
+        self.assertEqual(u"café", u"caffe")


### PR DESCRIPTION
When a test raises an exception is raised that contains non-ascii characters, the unittest raises an exception when trying to write XML file.
This commit should fix the problem.

I guess it's related to [issue #3](https://github.com/danielfm/unittest-xml-reporting/issues/3)

Also note that this will add an encoding header to every generated XML files.
