### PR TITLE
Added a small change to enable creation of distinct files for runs of the same testsuite

### DIFF
--- a/src/xmlrunner/__init__.py
+++ b/src/xmlrunner/__init__.py
@@ -124,7 +124,7 @@ class _XMLTestResult(_TextTestResult):
             self.stream.writeln(self.separator2)
             self.stream.writeln('%s' % test_info.get_error_info())
     
-    def _get_info_by_testcase(self):
+    def _get_info_by_testcase(self, outsuffix):
         """This method organizes test results by TestCase module. This
         information is used during the report generation, where a XML report
         will be generated for each TestCase.
@@ -139,7 +139,7 @@ class _XMLTestResult(_TextTestResult):
                 module = testcase.__module__ + '.'
                 if module == '__main__.':
                     module = ''
-                testcase_name = module + testcase.__name__
+                testcase_name = module + testcase.__name__ + outsuffix
                 
                 if not tests_by_testcase.has_key(testcase_name):
                     tests_by_testcase[testcase_name] = []
@@ -219,7 +219,7 @@ class _XMLTestResult(_TextTestResult):
     def generate_reports(self, test_runner):
         "Generates the XML reports to a given XMLTestRunner object."
         from xml.dom.minidom import Document
-        all_results = self._get_info_by_testcase()
+        all_results = self._get_info_by_testcase(test_runner.outsuffix)
         
         if isinstance(test_runner.output, basestring) and not \
             os.path.exists(test_runner.output):
@@ -259,7 +259,7 @@ class XMLTestRunner(TextTestRunner):
         if outsuffix:
           self.outsuffix = outsuffix
         else:
-          self.outsuffix = time.time()
+          self.outsuffix = str(time.time())
         self.elapsed_times = elapsed_times
     
     def _make_result(self):


### PR DESCRIPTION
This is useful when you are creating multiple testcases/testsuites of the same class at runtime. Right now, the same xml file is overwritten for successive runs of objects of the same testsuite class. This change allows the programmer to pass in a (unique) filename suffix. If not, it defaults to the current timestamp.
