### PR TITLE
_DelegateIO: Fallback to StringIO attributes

### DIFF
--- a/src/xmlrunner/__init__.py
+++ b/src/xmlrunner/__init__.py
@@ -30,9 +30,9 @@ class _DelegateIO(object):
         self._captured.write(text)
         self.delegate.write(text)
 
-    def getvalue(self):
-        return self._captured.getvalue()
-
+    def __getattr__(self, attr):
+        return getattr(self._captured, attr)
+	
 
 class _TestInfo(object):
     """This class keeps useful information about the execution of a


### PR DESCRIPTION
For the moment, I can not use Fabric for unit-testing in conjunction with untittest-xml-reporting because _DelegateIO doesn't have "isatty" and "flush" methods.
My change add __getattr__ method to _DelegateIO so isatty, flush and others requests are forwarded to the "_captured" StringIO object.
