### PR TITLE
fix indentation problem

### DIFF
--- a/src/xmlrunner/__init__.py
+++ b/src/xmlrunner/__init__.py
@@ -31,8 +31,8 @@ class _DelegateIO(object):
         self.delegate.write(text)
 
     def __getattr__(self, attr):
-	return getattr(self._captured, attr)
-	
+        return getattr(self._captured, attr)
+
 
 class _TestInfo(object):
     """This class keeps useful information about the execution of a


### PR DESCRIPTION
Fix commit 21fec4f465 indentation as it used tabulations instead of
spaces.

Sorry about that, didn't see the problem when reviewing the original patch on the github web interface.
