### PR TITLE
Fixing #45

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ xmlrunner_version = os.path.join(
     os.path.abspath(os.path.dirname(__file__)),
     'src', 'xmlrunner', 'version.py'
 )
-exec(compile(open(xmlrunner_version).read(), xmlrunner_version, 'exec'))
+exec(compile(open(xmlrunner_version,"rb").read(), xmlrunner_version, 'exec'))
 
 
 setup(


### PR DESCRIPTION
This fixes an issue when installing on Debian and Python 3.3.  This patch is released under the GNU LGPL v3.

It's not immediately clear to me why this issue reproduces on Debian and not other unixes (OSX 10.9 was also tested and worked fine either way).  The documentation for [open](http://docs.python.org/2/library/functions.html#open) suggests the use of binary mode as implemented "will improve portability" so presumably there is some platform default at work here.

This was tested on Python 3.3/Debian and a perusal of the 2.x documentation suggests nothing bad will happen in 2.7.6, but I have not actually tried it.
