### PR TITLE
pickup __version__ without importing from xmlrunner.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,17 @@
-from setuptools import setup
 
-from xmlrunner import get_version
+import os
+import sys
+from setuptools import setup, find_packages
+from distutils.util import convert_path
+
+main_ns = {}
+ver_path = convert_path('xmlrunner/version.py')
+with open(ver_path) as ver_file:
+    exec(ver_file.read(), main_ns)
 
 setup(
     name = 'unittest-xml-reporting',
-    version = get_version(),
+    version = main_ns['__version__'],
     author = 'Daniel Fernandes Martins',
     author_email = 'daniel.tritone@gmail.com',
     description = 'unittest-based test runner with Ant/JUnit like XML reporting.',

--- a/xmlrunner/__init__.py
+++ b/xmlrunner/__init__.py
@@ -1,8 +1,7 @@
-from runner import *
 
-VERSION = (2, 0, 0)
+__all__ = ('XMLTestRunner',)
 
-def get_version():
-    """Returns VERSION as string in X.Y.Z format.
-    """
-    return '.'.join(str(part) for part in VERSION)
+import xmlrunner.version
+from xmlrunner.runner import XMLTestRunner
+
+__version__ = xmlrunner.version.__version__

--- a/xmlrunner/runner.py
+++ b/xmlrunner/runner.py
@@ -1,10 +1,9 @@
-import sys
-import unittest
-
-from . import composite, result
 
 __all__ = ('XMLTestRunner',)
 
+import sys
+import unittest
+from xmlrunner import composite, result
 
 class XMLTestRunner(unittest.TextTestRunner):
     """Subclass of `TextTestRunner` which was modified so it uses a

--- a/xmlrunner/version.py
+++ b/xmlrunner/version.py
@@ -1,0 +1,3 @@
+
+# please follow semver
+__version__ = '2.0.0'


### PR DESCRIPTION
importing xmlrunner causes a race condition while doing the setup.
if later we add requirements that are missing, then importing xmlrunner will
end up in an ImportError. setup.py needs to not depend on the same dependencies
as xmlrunner (iow. just some generic code specific to distutils/setuptools.)

Also use semantic versioning; **version** is what PEP8 recommends.
distutils.version has classes to parse version strings if someone ever wants
to compare version strings.

see http://stackoverflow.com/questions/2058802/
