### PR TITLE
add non-ascii tests - improve to_unicode function

### DIFF
--- a/src/xmlrunner/result.py
+++ b/src/xmlrunner/result.py
@@ -18,11 +18,13 @@ except ImportError:
 
 
 def to_unicode(data):
-    if six.PY2:
-        return six.text_type(data).encode('utf-8')
-    else:
-        # default encoding is UTF-8
+    """Returns unicode in Python2 and str in Python3"""
+    try:
         return six.text_type(data)
+    except UnicodeDecodeError:
+        # Try utf8
+        return repr(data).decode('utf8', 'replace')
+
 
 def testcase_name(test_method):
     testcase = type(test_method)
@@ -354,7 +356,7 @@ class _XMLTestResult(_TextTestResult):
                     '%s%sTEST-%s-%s.xml' % (
                         test_runner.output, os.sep, suite,
                         test_runner.outsuffix
-                    ), 'w'
+                    ), 'wb'
                 )
                 try:
                     report_file.write(xml_content)

--- a/src/xmlrunner/runner.py
+++ b/src/xmlrunner/runner.py
@@ -46,7 +46,7 @@ class XMLTestRunner(TextTestRunner):
     """
     def __init__(self, output='.', outsuffix=None, stream=sys.stderr,
                  descriptions=True, verbosity=1, elapsed_times=True,
-                 failfast=False, encoding=None):
+                 failfast=False, encoding='utf8'):
         TextTestRunner.__init__(self, stream, descriptions, verbosity,
                                 failfast=failfast)
         self.verbosity = verbosity

--- a/src/xmlrunner/tests/testsuite.py
+++ b/src/xmlrunner/tests/testsuite.py
@@ -10,11 +10,12 @@ else:
     import unittest
 
 import xmlrunner
-from six import StringIO
+from six import StringIO, BytesIO
 from tempfile import mkdtemp
 from shutil import rmtree
 from glob import glob
 import os.path
+
 
 class XMLTestRunnerTestCase(unittest.TestCase):
     """
@@ -24,6 +25,9 @@ class XMLTestRunnerTestCase(unittest.TestCase):
         @unittest.skip("demonstrating skipping")
         def test_skip(self):
             pass   # pragma: no cover
+        @unittest.skip(u"demonstrating non-ascii skipping: éçà")
+        def test_non_ascii_skip(self):
+            pass
         def test_pass(self):
             pass
         def test_fail(self):
@@ -38,6 +42,8 @@ class XMLTestRunnerTestCase(unittest.TestCase):
             1 / 0
         def test_cdata_section(self):
             print('<![CDATA[content]]>')
+        def test_non_ascii_error(self):
+            self.assertEqual(u"éçà", 42)
 
     def setUp(self):
         self.stream = StringIO()
@@ -58,6 +64,7 @@ class XMLTestRunnerTestCase(unittest.TestCase):
         self.assertEqual(0, len(glob(os.path.join(outdir, '*xml'))))
         runner.run(suite)
         self.assertEqual(1, len(glob(os.path.join(outdir, '*xml'))))
+        return runner
 
     def test_basic_unittest_constructs(self):
         suite = unittest.TestSuite()
@@ -68,6 +75,21 @@ class XMLTestRunnerTestCase(unittest.TestCase):
         suite.addTest(self.DummyTest('test_unexpected_success'))
         suite.addTest(self.DummyTest('test_error'))
         self._test_xmlrunner(suite)
+
+    def test_xmlrunner_non_ascii(self):
+        suite = unittest.TestSuite()
+        suite.addTest(self.DummyTest('test_non_ascii_skip'))
+        suite.addTest(self.DummyTest('test_non_ascii_error'))
+        outdir = BytesIO()
+        runner = xmlrunner.XMLTestRunner(
+            stream=self.stream, output=outdir, verbosity=self.verbosity,
+            **self.runner_kwargs)
+        runner.run(suite)
+        outdir.seek(0)
+        output = outdir.read()
+        self.assertIn(
+            u'<skipped message="demonstrating non-ascii skipping: éçà" type="skip"/>'.encode('utf8'),
+            output)
 
     def test_xmlrunner_pass(self):
         suite = unittest.TestSuite()
@@ -113,7 +135,7 @@ class XMLTestRunnerTestCase(unittest.TestCase):
 
     def test_xmlrunner_stream(self):
         stream = self.stream
-        output = StringIO()
+        output = BytesIO()
         runner = xmlrunner.XMLTestRunner(
             stream=stream, output=output, verbosity=self.verbosity,
             **self.runner_kwargs)


### PR DESCRIPTION
The hardcoded utf8 isn't really nice but that was already the case...
Maybe sys.stdout.encoding (or sys.stderr.encoding...) should be used.
