### PR TITLE
Deal with Python2/3 differences - always dump bytes into output

### DIFF
--- a/src/xmlrunner/result.py
+++ b/src/xmlrunner/result.py
@@ -23,7 +23,7 @@ def to_unicode(data):
          return six.text_type(data)
     try:
         # Try utf8
-        return six.text_type(data).encode('utf-8')
+        return six.text_type(data)
     except UnicodeDecodeError as err:
         return repr(data).decode('utf8', 'replace')
 
@@ -358,7 +358,7 @@ class _XMLTestResult(_TextTestResult):
                     '%s%sTEST-%s-%s.xml' % (
                         test_runner.output, os.sep, suite,
                         test_runner.outsuffix
-                    ), 'w'
+                    ), 'wb'
                 )
                 try:
                     report_file.write(xml_content)

--- a/src/xmlrunner/runner.py
+++ b/src/xmlrunner/runner.py
@@ -46,7 +46,7 @@ class XMLTestRunner(TextTestRunner):
     """
     def __init__(self, output='.', outsuffix=None, stream=sys.stderr,
                  descriptions=True, verbosity=1, elapsed_times=True,
-                 failfast=False, encoding=None):
+                 failfast=False, encoding='utf8'):
         TextTestRunner.__init__(self, stream, descriptions, verbosity,
                                 failfast=failfast)
         self.verbosity = verbosity


### PR DESCRIPTION
We have to use u"" (or from **future** import unicode_literals) in a python2/3 basecode or we'll have str/bytes in python2 vs unicode/str in python3...
