### PR TITLE
Fixing the parsing of the produced XML in bamboo

### DIFF
--- a/src/xmlrunner/result.py
+++ b/src/xmlrunner/result.py
@@ -44,7 +44,7 @@ def to_unicode(data):
         # Try utf8
         return six.text_type(data)
     except UnicodeDecodeError as err:
-        return repr(data).decode('UTF-8', 'replace')
+        return repr(data).decode('utf8', 'replace')
 
 
 def safe_unicode(data, encoding=None):
@@ -375,10 +375,6 @@ class _XMLTestResult(_TextTestResult):
             )
             for test in tests:
                 _XMLTestResult._report_testcase(suite, test, testsuite, doc)
-            
-            print 
-            print "#"* 100
-            print 'xml content in encoding ', test_runner.encoding
             xml_content = doc.toprettyxml(indent='\t', encoding=test_runner.encoding)
 
             if isinstance(test_runner.output, six.string_types):


### PR DESCRIPTION
Please consider this pull request. I have bamboo running a django test bed with the unittest-xml-reporting test runner.

However these error are thrown from the java framework (OSX build agent):

```
2014-11-08 21:01:18,945 ERROR [pool-139-thread-6] [TestCollationServiceImpl] Failed to parse test result file "/Users/bambooagent/bamboo-agent-home/xml-data/build-dir/SW-DCD1-JOB1/src/TEST-code_doc.tests.test_project_revision.ProjectRevis
ionsTest-20141108200109.xml"
org.xml.sax.SAXParseException: Invalid encoding name "utf8".
        at org.apache.xerces.parsers.AbstractSAXParser.parse(Unknown Source)
        at com.atlassian.bamboo.build.test.junit.JunitTestResultsParser.parse(JunitTestResultsParser.java:90)
        at com.atlassian.bamboo.build.test.junit.JunitTestReportCollector.collect(JunitTestReportCollector.java:40)
        at com.atlassian.bamboo.build.test.TestCollationServiceImpl$1$1.run(TestCollationServiceImpl.java:136)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:439)
        at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
        at java.util.concurrent.FutureTask.run(FutureTask.java:138)
        at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:895)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:918)
        at java.lang.Thread.run(Thread.java:695)
```

The simple fix of the pull request completely solves the issue.

Best,
Raffi
