### PR TITLE
Although cStringIO is faster it does not handle unicode

### DIFF
--- a/src/xmlrunner/result.py
+++ b/src/xmlrunner/result.py
@@ -4,15 +4,9 @@ import sys
 import time
 import six
 import re
+from six.moves import StringIO
 
 from .unittest import TestResult, _TextTestResult
-
-try:
-    # Removed in Python 3
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
-
 
 
 # Matches invalid XML1.0 unicode characters, like control characters:

--- a/src/xmlrunner/runner.py
+++ b/src/xmlrunner/runner.py
@@ -5,13 +5,6 @@ import time
 from .unittest import TextTestRunner
 from .result import _XMLTestResult
 
-try:
-    # Removed in Python 3
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
-
-
 # see issue #74, the encoding name needs to be one of
 # http://www.iana.org/assignments/character-sets/character-sets.xhtml
 UTF8 = 'UTF-8'


### PR DESCRIPTION
https://docs.python.org/2/library/stringio.html#module-cStringIO

Unlike the StringIO module, this module is not able to accept Unicode
strings that cannot be encoded as plain ASCII strings.
