### PR TITLE
fix coverage bug with 4.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = begin,py{26,27,33,34},py27-django{lts,prev,curr},end
 
 [testenv]
 deps=
-    coverage
+    coverage==3.7.1
     djangolts: django==1.4.19
     djangoprev: django==1.6.10
     djangocurr: django==1.7.4


### PR DESCRIPTION
see https://bitbucket.org/ned/coveragepy/issues/419/nosource-no-source-for-code-path-to-c