### PR TITLE
Fix 'getvalue' AttributeError when test fails during __call__

### DIFF
--- a/tests/testsuite.py
+++ b/tests/testsuite.py
@@ -64,6 +64,17 @@ class XMLTestRunnerTestCase(unittest.TestCase):
                 with self.subTest(i=i):
                     self.fail('this is a subtest.')
 
+    class DummyErrorInCallTest(unittest.TestCase):
+        def __call__(self, result):
+            try:
+                raise Exception('Massive fail')
+            except Exception:
+                result.addError(self, sys.exc_info())
+                return
+            super(DummyErrorInCallTest, self).__call__(result)
+        def test_pass(self):
+            pass
+
     def setUp(self):
         self.stream = StringIO()
         self.outdir = mkdtemp()
@@ -311,3 +322,7 @@ class XMLTestRunnerTestCase(unittest.TestCase):
         finally:
             sys.stdout, sys.stderr = old_stdout, old_stderr
 
+    def test_xmlrunner_error_in_call(self):
+        suite = unittest.TestSuite()
+        suite.addTest(self.DummyErrorInCallTest('test_pass'))
+        self._test_xmlrunner(suite)

--- a/tests/testsuite.py
+++ b/tests/testsuite.py
@@ -326,3 +326,5 @@ class XMLTestRunnerTestCase(unittest.TestCase):
         suite = unittest.TestSuite()
         suite.addTest(self.DummyErrorInCallTest('test_pass'))
         self._test_xmlrunner(suite)
+        testsuite_output = self.stream.getvalue()
+        self.assertIn('Exception: Massive fail', testsuite_output)

--- a/xmlrunner/result.py
+++ b/xmlrunner/result.py
@@ -190,8 +190,13 @@ class _XMLTestResult(_TextTestResult):
             self.stream.write(" ... ")
 
     def _save_output_data(self):
-        self._stdout_data = sys.stdout.getvalue()
-        self._stderr_data = sys.stderr.getvalue()
+        # Only try to get sys.stdout and sys.sterr as they not be
+        # StringIO yet, e.g. when test fails during __call__
+        try:
+            self._stdout_data = sys.stdout.getvalue()
+            self._stderr_data = sys.stderr.getvalue()
+        except AttributeError:
+            pass
 
     def stopTest(self, test):
         """
@@ -339,7 +344,8 @@ class _XMLTestResult(_TextTestResult):
         stdout = StringIO()
         for test in tests:
             # Merge the stdout from the tests in a class
-            stdout.write(test.stdout)
+            if test.stdout is not None:
+                stdout.write(test.stdout)
         _XMLTestResult._createCDATAsections(
             xml_document, systemout, stdout.getvalue())
 
@@ -349,7 +355,8 @@ class _XMLTestResult(_TextTestResult):
         stderr = StringIO()
         for test in tests:
             # Merge the stderr from the tests in a class
-            stderr.write(test.stderr)
+            if test.stderr is not None:
+                stderr.write(test.stderr)
         _XMLTestResult._createCDATAsections(
             xml_document, systemerr, stderr.getvalue())
 
@@ -469,7 +476,12 @@ class _XMLTestResult(_TextTestResult):
         """Converts a sys.exc_info()-style tuple of values into a string."""
         if six.PY3:
             # It works fine in python 3
-            return super(_XMLTestResult, self)._exc_info_to_string(err, test)
+            try:
+                return super(_XMLTestResult, self)._exc_info_to_string(
+                    err, test)
+            except AttributeError:
+                # We keep going using the legacy python <= 2 way
+                pass
 
         # This comes directly from python2 unittest
         exctype, value, tb = err
@@ -485,8 +497,16 @@ class _XMLTestResult(_TextTestResult):
             msgLines = traceback.format_exception(exctype, value, tb)
 
         if self.buffer:
-            output = sys.stdout.getvalue()
-            error = sys.stderr.getvalue()
+            # Only try to get sys.stdout and sys.sterr as they not be
+            # StringIO yet, e.g. when test fails during __call__
+            try:
+                output = sys.stdout.getvalue()
+            except AttributeError:
+                output = None
+            try:
+                error = sys.stderr.getvalue()
+            except AttributeError:
+                error = None
             if output:
                 if not output.endswith('\n'):
                     output += '\n'


### PR DESCRIPTION
sys.stdout and sys.sterr may not necessarily be StringIO
yet. We should catch AttributeError when trying to call
getvalue() on them.

Fixes: #83