### PR TITLE
Integration with diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,24 @@ Tells the test runner where to put the XML reports. If the directory
 couldn't be found, the test runner will try to create it before
 generate the XML files.
 
+## Pretty tracebacks
+
+XMLTestRunner provides optional integration with diagnostics module (https://pypi.python.org/pypi/diagnostics).
+
+Usage example:
+
+````
+import unittest
+from xmlrunner.extra.diagnosticstestrunner import XMLTestRunner
+
+class MyTestCase(unittest.TestCase):
+    def test_mytest(self):
+        self.assertTrue(True)
+
+if __name__ == '__main__':
+unittest.main(testRunner=XMLTestRunner())
+````
+
 
 ## Contributing
 

--- a/tests/diagnostics_test.py
+++ b/tests/diagnostics_test.py
@@ -1,0 +1,33 @@
+from six import StringIO
+from tempfile import mkdtemp
+
+from xmlrunner.unittest import unittest
+
+try:
+    import diagnostics
+except ImportError:
+    diagnostics = None
+
+class DiagnosticsTest(unittest.TestCase):
+    class DummyTest(unittest.TestCase):
+        # We should reuse code from testsuite.py in future.
+        def test_fail(self):
+            self.assertTrue(False)
+
+    def setUp(self):
+        self.stream = StringIO()
+        self.outdir = mkdtemp()
+
+    @unittest.skipIf(diagnostics is None, 'diagnostics not found')
+    def test_diagnostics_runner(self):
+        from xmlrunner.extra.diagnosticstestrunner import DiagnosticsTestInfo, XMLTestRunner
+        suite = unittest.TestSuite()
+        suite.addTest(self.DummyTest('test_fail'))
+        runner = XMLTestRunner(stream=self.stream, output=self.outdir)
+        self.assertEquals(runner.info_cls, DiagnosticsTestInfo)
+        result = runner.run(suite)
+        self.assertEqual(len(result.failures), 1)
+        failure_obj = result.failures[0][0]
+        self.assertTrue(isinstance(failure_obj, DiagnosticsTestInfo))
+        failure_attrs = failure_obj.get_failure_attributes()
+        self.assertIn("details", failure_attrs.keys())

--- a/tests/testsuite.py
+++ b/tests/testsuite.py
@@ -3,8 +3,11 @@
 
 """Executable module to test unittest-xml-reporting.
 """
+import collections
+import logging
 import sys
 
+from mock import patch
 from xmlrunner.unittest import unittest
 import xmlrunner
 import doctest
@@ -242,6 +245,13 @@ class XMLTestRunnerTestCase(unittest.TestCase):
         self._test_xmlrunner(suite)
         testsuite_output = self.stream.getvalue()
         self.assertIn('should be printed', testsuite_output)
+
+    @patch("xmlrunner.result.LOG")
+    def test_unittest_logger(self, logger):
+        suite = unittest.TestSuite()
+        suite.addTest(self.DummyTest('test_fail'))
+        self._test_xmlrunner(suite)
+        self.assertTrue(logger.error.called)
 
     @unittest.skipIf(not hasattr(unittest.TestCase,'subTest'),
         'unittest.TestCase.subTest not present.')

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ deps =
     coverage
     djangolts: django==1.8.7
     djangocurr: django==1.9
+    mock
 commands =
     coverage run --append setup.py test
     coverage report --omit='.tox/*'

--- a/xmlrunner/__init__.py
+++ b/xmlrunner/__init__.py
@@ -5,6 +5,16 @@ This module provides the XMLTestRunner class, which is heavily based on the
 default TextTestRunner.
 """
 
+import logging
+try:
+    from logging import NullHandler
+except ImportError:
+    class NullHandler(logging.Handler):
+        def emit(self, record):
+            pass
+
+logging.getLogger(__name__).addHandler(NullHandler())
+
 # Allow version to be detected at runtime.
 from .version import __version__
 

--- a/xmlrunner/extra/diagnosticstestrunner.py
+++ b/xmlrunner/extra/diagnosticstestrunner.py
@@ -1,0 +1,36 @@
+"""Integartion with diagnostics module."""
+
+from diagnostics import exception_hook, FileStorage, ExceptionInfo
+
+from xmlrunner.result import _TestInfo
+from xmlrunner.runner import XMLTestRunner as _XMLTestRunner
+
+
+class DiagnosticsTestInfo(_TestInfo):
+
+    def __init__(self, test_result, test_method, outcome=_TestInfo.SUCCESS,
+                 err=None, subTest=None):
+        super(DiagnosticsTestInfo, self).__init__(
+            test_result, test_method, outcome=outcome, err=err, subTest=subTest)
+        self._details_path = self._exception_details_path(err)
+        if err:
+            exception_hook(*err)
+
+    def _exception_details_path(self, err):
+        """Return file name with details about exception err"""
+        if isinstance(err, basestring) or err is None:
+            return ""
+        return exception_hook.storage._build_path_to_file(ExceptionInfo(err))
+
+    def get_failure_attributes(self, *args, **kwargs):
+        res = super(DiagnosticsTestInfo, self).get_failure_attributes(*args, **kwargs)
+        res["details"] = self._details_path
+        return res
+
+
+class XMLTestRunner(_XMLTestRunner):
+    def __init__(self, *args, **kwargs):
+        directory = kwargs.get("output", ".")
+        exception_hook.enable(FileStorage(directory))
+        kwargs["info_cls"] = DiagnosticsTestInfo
+        super(XMLTestRunner, self).__init__(*args, **kwargs)

--- a/xmlrunner/extra/diagnosticstestrunner.py
+++ b/xmlrunner/extra/diagnosticstestrunner.py
@@ -1,4 +1,22 @@
-"""Integartion with diagnostics module."""
+"""Integration with diagnostics module.
+
+Custom test runner that uses diagnostics module to generate
+pretty tracebacks in html format and adds links to generated html
+files into resulted xml report (every "error" tag now has "details"
+attribute).
+
+Usage:
+
+import unittest
+from xmlrunner.extra.diagnosticstestrunner import XMLTestRunner
+
+class MyTestCase(unittest.TestCase):
+    def test_mytest(self):
+        self.assertTrue(True)
+
+if __name__ == '__main__':
+    unittest.main(testRunner=XMLTestRunner())
+"""
 
 from diagnostics import exception_hook, FileStorage, ExceptionInfo
 

--- a/xmlrunner/result.py
+++ b/xmlrunner/result.py
@@ -65,7 +65,7 @@ def to_unicode(data):
         # Try utf8
         return six.text_type(data)
     except UnicodeDecodeError:
-        return repr(data).decode('utf8', 'replace')
+        return str(data).decode('utf8', 'replace')
 
 
 def safe_unicode(data, encoding=None):

--- a/xmlrunner/result.py
+++ b/xmlrunner/result.py
@@ -152,7 +152,7 @@ class _XMLTestResult(_TextTestResult):
     Used by XMLTestRunner.
     """
     def __init__(self, stream=sys.stderr, descriptions=1, verbosity=1,
-                 elapsed_times=True, properties=None):
+                 elapsed_times=True, properties=None, info_cls=_TestInfo):
         _TextTestResult.__init__(self, stream, descriptions, verbosity)
         self.buffer = True  # we are capturing test output
         self._stdout_data = None
@@ -161,6 +161,7 @@ class _XMLTestResult(_TextTestResult):
         self.callback = None
         self.elapsed_times = elapsed_times
         self.properties = properties  # junit testsuite properties
+        self._info_cls = info_cls
 
     def _prepare_callback(self, test_info, target_list, verbose_str,
                           short_str):
@@ -230,7 +231,7 @@ class _XMLTestResult(_TextTestResult):
         """
         self._save_output_data()
         self._prepare_callback(
-            _TestInfo(self, test), self.successes, 'OK', '.'
+            self._info_cls(self, test), self.successes, 'OK', '.'
         )
 
     @failfast
@@ -240,7 +241,7 @@ class _XMLTestResult(_TextTestResult):
         """
         LOG.error(self._exc_info_to_string(err, test))
         self._save_output_data()
-        testinfo = _TestInfo(self, test, _TestInfo.FAILURE, err)
+        testinfo = self._info_cls(self, test, _TestInfo.FAILURE, err)
         self.failures.append((
             testinfo,
             self._exc_info_to_string(err, test)
@@ -254,7 +255,7 @@ class _XMLTestResult(_TextTestResult):
         """
         LOG.error(self._exc_info_to_string(err, test))
         self._save_output_data()
-        testinfo = _TestInfo(self, test, _TestInfo.ERROR, err)
+        testinfo = self._info_cls(self, test, _TestInfo.ERROR, err)
         self.errors.append((
             testinfo,
             self._exc_info_to_string(err, test)
@@ -267,7 +268,7 @@ class _XMLTestResult(_TextTestResult):
         """
         if err is not None:
             self._save_output_data()
-            testinfo = _TestInfo(self, testcase, _TestInfo.ERROR, err, subTest=test)
+            testinfo = self._info_cls(self, testcase, _TestInfo.ERROR, err, subTest=test)
             self.errors.append((
                 testinfo,
                 self._exc_info_to_string(err, testcase)
@@ -279,7 +280,7 @@ class _XMLTestResult(_TextTestResult):
         Called when a test method was skipped.
         """
         self._save_output_data()
-        testinfo = _TestInfo(self, test, _TestInfo.SKIP, reason)
+        testinfo = self._info_cls(self, test, _TestInfo.SKIP, reason)
         self.skipped.append((testinfo, reason))
         self._prepare_callback(testinfo, [], 'SKIP', 'S')
 

--- a/xmlrunner/result.py
+++ b/xmlrunner/result.py
@@ -1,4 +1,5 @@
 
+import logging
 import os
 import sys
 import time
@@ -10,6 +11,7 @@ from six.moves import StringIO
 
 from .unittest import TestResult, _TextTestResult, failfast
 
+LOG = logging.getLogger(__name__)
 
 # Matches invalid XML1.0 unicode characters, like control characters:
 # http://www.w3.org/TR/2006/REC-xml-20060816/#charsets
@@ -226,6 +228,7 @@ class _XMLTestResult(_TextTestResult):
         """
         Called when a test method fails.
         """
+        LOG.error(self._exc_info_to_string(err, test))
         self._save_output_data()
         testinfo = _TestInfo(self, test, _TestInfo.FAILURE, err)
         self.failures.append((
@@ -239,6 +242,7 @@ class _XMLTestResult(_TextTestResult):
         """
         Called when a test method raises an error.
         """
+        LOG.error(self._exc_info_to_string(err, test))
         self._save_output_data()
         testinfo = _TestInfo(self, test, _TestInfo.ERROR, err)
         self.errors.append((

--- a/xmlrunner/result.py
+++ b/xmlrunner/result.py
@@ -134,6 +134,16 @@ class _TestInfo(object):
         """
         return self.test_exception_info
 
+    def get_failure_attributes(self):
+        res_attrs = {}
+        if self.outcome != self.SKIP:
+            res_attrs["type"] = safe_unicode(self.err[0].__name__)
+            res_attrs["message"] = safe_unicode(self.err[1])
+        else:
+            res_attrs["type"] = "skip"
+            res_attrs["message"] = safe_unicode(self.err)
+        return res_attrs
+
 
 class _XMLTestResult(_TextTestResult):
     """
@@ -412,21 +422,12 @@ class _XMLTestResult(_TextTestResult):
             elem_name = ('failure', 'error', 'skipped')[test_result.outcome-1]
             failure = xml_document.createElement(elem_name)
             testcase.appendChild(failure)
+            for attr, value in test_result.get_failure_attributes().items():
+                failure.setAttribute(attr, value)
             if test_result.outcome != _TestInfo.SKIP:
-                failure.setAttribute(
-                    'type',
-                    safe_unicode(test_result.err[0].__name__)
-                )
-                failure.setAttribute(
-                    'message',
-                    safe_unicode(test_result.err[1])
-                )
                 error_info = safe_unicode(test_result.get_error_info())
                 _XMLTestResult._createCDATAsections(
                     xml_document, failure, error_info)
-            else:
-                failure.setAttribute('type', 'skip')
-                failure.setAttribute('message', safe_unicode(test_result.err))
 
     _report_testcase = staticmethod(_report_testcase)
 

--- a/xmlrunner/runner.py
+++ b/xmlrunner/runner.py
@@ -3,7 +3,7 @@ import sys
 import time
 
 from .unittest import TextTestRunner
-from .result import _XMLTestResult
+from .result import _XMLTestResult, _TestInfo
 
 # see issue #74, the encoding name needs to be one of
 # http://www.iana.org/assignments/character-sets/character-sets.xhtml
@@ -16,7 +16,7 @@ class XMLTestRunner(TextTestRunner):
     """
     def __init__(self, output='.', outsuffix=None, stream=sys.stderr,
                  descriptions=True, verbosity=1, elapsed_times=True,
-                 failfast=False, buffer=False, encoding=UTF8):
+                 failfast=False, buffer=False, encoding=UTF8, info_cls=_TestInfo):
         TextTestRunner.__init__(self, stream, descriptions, verbosity,
                                 failfast=failfast, buffer=buffer)
         self.verbosity = verbosity
@@ -28,6 +28,10 @@ class XMLTestRunner(TextTestRunner):
             outsuffix = time.strftime("%Y%m%d%H%M%S")
         self.outsuffix = outsuffix
         self.elapsed_times = elapsed_times
+        if issubclass(info_cls, _TestInfo):
+            self.info_cls = info_cls
+        else:
+            self.info_cls = _TestInfo
 
     def _make_result(self):
         """
@@ -35,7 +39,8 @@ class XMLTestRunner(TextTestRunner):
         information about the executed tests.
         """
         return _XMLTestResult(
-            self.stream, self.descriptions, self.verbosity, self.elapsed_times
+            self.stream, self.descriptions, self.verbosity, self.elapsed_times,
+            info_cls=self.info_cls
         )
 
     def run(self, test):


### PR DESCRIPTION
* configure logger for library
* extra: integration with diagnostics module (its optional)
* fix bug: plain text instead of strings like 'some\n python\n string' in resulted xml