### PR TITLE
Remove pinned version for coverage.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = begin,py{26,27,33,34},py27-django{lts,prev,curr},end
 
 [testenv]
 deps=
-    coverage==3.7.1
+    coverage
     djangolts: django==1.4.22
     djangoprev: django==1.6.11
     djangocurr: django==1.7.10


### PR DESCRIPTION
Issue was fixed in coverage:
https://bitbucket.org/ned/coveragepy/issues/419/nosource-no-source-for-code-path-to-c