### PR TITLE
Use coveralls.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: python
 python:
   - "2.7"
 install:
-  - pip install tox
+  - pip install tox coveralls
 script:
   - tox
+after_success:
+  - coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,14 @@ envlist = begin,py{26,27,33,34},py27-django{lts,curr},end,quality
 [testenv]
 deps =
     coverage
+    coveralls
     djangolts: django==1.8.7
     djangocurr: django==1.9
 commands =
     coverage run --append setup.py test
     coverage report --omit='.tox/*'
+    coveralls
+passenv = CI TRAVIS_BUILD_ID TRAVIS TRAVIS_BRANCH TRAVIS_JOB_NUMBER TRAVIS_PULL_REQUEST TRAVIS_JOB_ID TRAVIS_REPO_SLUG TRAVIS_COMMIT
 
 [testenv:begin]
 commands = coverage erase


### PR DESCRIPTION
The intent is that if code coverage report are combined (?), then
parallelizing with tox-travis may make sense.