### PR TITLE
Removed hardcoded buffer flag in result.py

### DIFF
--- a/xmlrunner/result.py
+++ b/xmlrunner/result.py
@@ -140,9 +140,9 @@ class _XMLTestResult(_TextTestResult):
     Used by XMLTestRunner.
     """
     def __init__(self, stream=sys.stderr, descriptions=1, verbosity=1,
-                 elapsed_times=True, properties=None):
+                 elapsed_times=True, properties=None, buffer=True):
         _TextTestResult.__init__(self, stream, descriptions, verbosity)
-        self.buffer = True  # we are capturing test output
+        self.buffer = buffer
         self._stdout_data = None
         self._stderr_data = None
         self.successes = []

--- a/xmlrunner/runner.py
+++ b/xmlrunner/runner.py
@@ -36,7 +36,7 @@ class XMLTestRunner(TextTestRunner):
         """
         return _XMLTestResult(
             self.stream, self.descriptions, self.verbosity, self.elapsed_times,
-            self.buffer
+            buffer=self.buffer
         )
 
     def run(self, test):

--- a/xmlrunner/runner.py
+++ b/xmlrunner/runner.py
@@ -35,7 +35,8 @@ class XMLTestRunner(TextTestRunner):
         information about the executed tests.
         """
         return _XMLTestResult(
-            self.stream, self.descriptions, self.verbosity, self.elapsed_times
+            self.stream, self.descriptions, self.verbosity, self.elapsed_times,
+            self.buffer
         )
 
     def run(self, test):


### PR DESCRIPTION
This flag is needed for debug logs. When is setted to True then output is buffered and never displayed.