### PR TITLE
Exclude libraries from coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[report]
+omit =
+    */site-packages/*
+    */pypy-*/*
+    .tox/*
+    tests/*
+    */*virtualenv*/*

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps =
     djangocurr: django==1.9.1
 commands =
     coverage run --append setup.py test
-    coverage report --omit='.tox/*'
+    coverage report
     codecov -e TOXENV
     -coveralls
 passenv = CI TRAVIS_BUILD_ID TRAVIS TRAVIS_BRANCH TRAVIS_JOB_NUMBER TRAVIS_PULL_REQUEST TRAVIS_JOB_ID TRAVIS_REPO_SLUG TRAVIS_COMMIT
@@ -25,8 +25,8 @@ commands = coverage erase
 
 [testenv:end]
 commands =
-    coverage report --omit='.tox/*'
-    coverage html --omit='.tox/*'
+    coverage report
+    coverage html
 
 [testenv:quality]
 ignore_outcome = True


### PR DESCRIPTION
Both for local tox build and https://coveralls.io/github/xmlrunner/unittest-xml-reporting