### PR TITLE
fix stream buffering

### DIFF
--- a/xmlrunner/runner.py
+++ b/xmlrunner/runner.py
@@ -16,7 +16,7 @@ class XMLTestRunner(TextTestRunner):
     """
     def __init__(self, output='.', outsuffix=None, stream=sys.stderr,
                  descriptions=True, verbosity=1, elapsed_times=True,
-                 failfast=False, buffer=False, encoding=UTF8,
+                 failfast=False, buffer=True, encoding=UTF8,
                  resultclass=None, warnings=None):
         TextTestRunner.__init__(self, stream, descriptions, verbosity,
                                 failfast=failfast, buffer=buffer)

--- a/xmlrunner/runner.py
+++ b/xmlrunner/runner.py
@@ -17,7 +17,7 @@ class XMLTestRunner(TextTestRunner):
     def __init__(self, output='.', outsuffix=None, stream=sys.stderr,
                  descriptions=True, verbosity=1, elapsed_times=True,
                  failfast=False, buffer=False, encoding=UTF8,
-                 resultclass=None):
+                 resultclass=None, warnings=None):
         TextTestRunner.__init__(self, stream, descriptions, verbosity,
                                 failfast=failfast, buffer=buffer)
         self.verbosity = verbosity
@@ -52,6 +52,7 @@ class XMLTestRunner(TextTestRunner):
             # Prepare the test execution
             result = self._make_result()
             result.failfast = self.failfast
+            result.buffer = self.buffer
             if hasattr(test, 'properties'):
                 # junit testsuite properties
                 result.properties = test.properties


### PR DESCRIPTION
Hi,

I am having issues with stdout/stderr buffering when invoking xmlrunner from unittest.main. Eg if I have a file called test.py with this content:

```python
#!/usr/bin/env python3

import unittest
import xmlrunner

class FooTest(unittest.TestCase):

    def test_success(self):
        print('succeeding')

    def test_failure(self):
        print('failing')
        self.fail('herk! bleh')

if __name__ == '__main__':
    unittest.main(testRunner=xmlrunner.XMLTestRunner, buffer=False)
```

Then when running `./test.py`,  stdout stays hidden, even though I explicitly added `buffer=False`.

I found what was causing this and attempted to fix it. The commit log explains where the issues lied.

I tried to install tox and run `make test`, but I did not have the patience to debug the dependency errors I was getting (the command took 15 minutes on my laptop, and spewed >30k lines of logs).

If any failure comes up on the Travis build, I will look into it.