### PR TITLE
Fix the check that the output stream is a string

### DIFF
--- a/xmlrunner/result.py
+++ b/xmlrunner/result.py
@@ -149,7 +149,7 @@ class XMLTestResult(result.TestResult):
         # Assume that self.out_dir is a stream by default
         stream = self.out_dir
 
-        if type(stream) in six.string_types:
+        if isinstance(stream, six.string_types):
             filename = '{0}{1}TESTS-TestSuites-{3}.xml'.format(stream, os.sep,
                 'suite', self.out_suffix)
 


### PR DESCRIPTION
You can't use type(x) in six.string_types.
You need to do isinstance(x, six.string_types)