### PR TITLE
Fixes #146

### DIFF
--- a/tests/django_test.py
+++ b/tests/django_test.py
@@ -98,6 +98,23 @@ class DjangoTest(unittest.TestCase):
         self.assertTrue(path.exists(expected_file),
                         'did not generate xml report where expected.')
 
+    def test_django_single_report_create_folder(self):
+        intermediate_directory = 'report'
+        directory = path.join(self.tmpdir, intermediate_directory)
+        self._override_settings(
+            TEST_OUTPUT_DIR=directory,
+            TEST_OUTPUT_FILE_NAME='results.xml',
+            TEST_OUTPUT_VERBOSE=0,
+            TEST_RUNNER='xmlrunner.extra.djangotestrunner.XMLTestRunner')
+        apps.populate(settings.INSTALLED_APPS)
+        runner_class = get_runner(settings)
+        runner = runner_class()
+        suite = runner.build_suite()
+        runner.run_suite(suite)
+        expected_file = path.join(directory, 'results.xml')
+        self.assertTrue(path.exists(expected_file),
+                        'did not generate xml report where expected.')
+
     def test_django_multiple_reports(self):
         self._override_settings(
             TEST_OUTPUT_DIR=self.tmpdir,

--- a/xmlrunner/extra/djangotestrunner.py
+++ b/xmlrunner/extra/djangotestrunner.py
@@ -9,6 +9,7 @@ how to configure a custom TestRunner in a Django project, please read the
 Django docs website.
 """
 
+import os
 import xmlrunner
 import os.path
 from django.conf import settings
@@ -31,6 +32,8 @@ class XMLTestRunner(DiscoverRunner):
             verbosity=verbosity, descriptions=descriptions,
             failfast=self.failfast)
         if single_file is not None:
+            if not os.path.exists(output_dir):
+                os.makedirs(output_dir)
             file_path = os.path.join(output_dir, single_file)
             with open(file_path, 'wb') as xml:
                 return xmlrunner.XMLTestRunner(


### PR DESCRIPTION
Using TEST_OUTPUT_FILE_NAME with Django does not create intermediate folders specified in TEST_OUTPUT_DIR
Now it creates intermediate folders if they don't exist. Includes tests.
Fixes #146 