### PR TITLE
Ability to define custom test_runner for Django test runner

### DIFF
--- a/tests/django_test.py
+++ b/tests/django_test.py
@@ -4,6 +4,7 @@ import sys
 import os
 from os import path
 import glob
+import mock
 import tempfile
 import shutil
 
@@ -129,3 +130,20 @@ class DjangoTest(unittest.TestCase):
         self.assertTrue(test_files,
                         'did not generate xml reports where expected.')
         self.assertEqual(2, len(test_files))
+
+    def test_django_runner_extension(self):
+        from xmlrunner.extra.djangotestrunner import XMLTestRunner
+
+        class MyDjangoRunner(XMLTestRunner):
+            test_runner = mock.Mock()
+        
+        self._override_settings(
+            TEST_OUTPUT_DIR=self.tmpdir,
+            TEST_OUTPUT_VERBOSE=0)
+        apps.populate(settings.INSTALLED_APPS)
+
+        runner = MyDjangoRunner()
+        suite = runner.build_suite(test_labels=None)
+        runner.run_suite(suite)
+        
+        self.assertTrue(MyDjangoRunner.test_runner.called)

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps =
     djangolts: django>=1.8.8,<1.9.0
     djangocurr: django>=1.9.1
     lxml>=3.6.0
+    mock
 commands =
     coverage run --append setup.py test
     coverage report --omit='.tox/*'

--- a/xmlrunner/extra/djangotestrunner.py
+++ b/xmlrunner/extra/djangotestrunner.py
@@ -36,13 +36,11 @@ class XMLTestRunner(DiscoverRunner):
 
         # For single file case we are able to create file here
         # But for multiple files case files will be created inside runner/results
-        if single_file is not None:
+        if single_file is None:  # output will be a path (folder)
+            output = output_dir
+        else:  # output will be a stream
             if not os.path.exists(output_dir):
                 os.makedirs(output_dir)
-
-        if single_file is None:  # output is a stream
-            output = output_dir
-        else:  # output is a folder
             file_path = os.path.join(output_dir, single_file)
             output = open(file_path, 'wb')
 
@@ -55,9 +53,9 @@ class XMLTestRunner(DiscoverRunner):
         )
 
     def run_suite(self, suite, **kwargs):
-        kwargs = self.get_test_runner_kwargs()
-        runner = self.test_runner(**kwargs)
+        runner_kwargs = self.get_test_runner_kwargs()
+        runner = self.test_runner(**runner_kwargs)
         results = runner.run(suite)
-        if hasattr(kwargs['output'], 'close'):
-            kwargs['output'].close()
+        if hasattr(runner_kwargs['output'], 'close'):
+            runner_kwargs['output'].close()
         return results

--- a/xmlrunner/extra/djangotestrunner.py
+++ b/xmlrunner/extra/djangotestrunner.py
@@ -17,27 +17,47 @@ from django.test.runner import DiscoverRunner
 
 
 class XMLTestRunner(DiscoverRunner):
+    test_runner = xmlrunner.XMLTestRunner
 
-    def run_suite(self, suite, **kwargs):
-        dummy = kwargs  # unused
+    def get_resultclass(self):
+        # Django provides `DebugSQLTextTestResult` if `debug_sql` argument is True
+        # To use `xmlrunner.result._XMLTestResult` we supress default behavior
+        return None
+
+    def get_test_runner_kwargs(self):
+        # We use separate verbosity setting for our runner
         verbosity = getattr(settings, 'TEST_OUTPUT_VERBOSE', 1)
-        # XXX: verbosity = self.verbosity
         if isinstance(verbosity, bool):
             verbosity = (1, 2)[verbosity]
-        descriptions = getattr(settings, 'TEST_OUTPUT_DESCRIPTIONS', False)
+        verbosity = verbosity  # not self.verbosity
+
         output_dir = getattr(settings, 'TEST_OUTPUT_DIR', '.')
         single_file = getattr(settings, 'TEST_OUTPUT_FILE_NAME', None)
 
-        kwargs = dict(
-            verbosity=verbosity, descriptions=descriptions,
-            failfast=self.failfast)
+        # For single file case we are able to create file here
+        # But for multiple files case files will be created inside runner/results
         if single_file is not None:
             if not os.path.exists(output_dir):
                 os.makedirs(output_dir)
+
+        if single_file is None:  # output is a stream
+            output = output_dir
+        else:  # output is a folder
             file_path = os.path.join(output_dir, single_file)
-            with open(file_path, 'wb') as xml:
-                return xmlrunner.XMLTestRunner(
-                    output=xml, **kwargs).run(suite)
-        else:
-            return xmlrunner.XMLTestRunner(
-                output=output_dir, **kwargs).run(suite)
+            output = open(file_path, 'wb')
+
+        return dict(
+            verbosity=verbosity,
+            descriptions=getattr(settings, 'TEST_OUTPUT_DESCRIPTIONS', False),
+            failfast=self.failfast,
+            resultclass=self.get_resultclass(),
+            output=output,
+        )
+
+    def run_suite(self, suite, **kwargs):
+        kwargs = self.get_test_runner_kwargs()
+        runner = self.test_runner(**kwargs)
+        results = runner.run(suite)
+        if hasattr(kwargs['output'], 'close'):
+            kwargs['output'].close()
+        return results


### PR DESCRIPTION
1. `xmlrunner.XMLTestRunner` was hardcoded into `xmlrunner.extra.djangotestrunner.XMLTestRunner`. Now it's overridable attribute of `xmlrunner.extra.djangotestrunner.XMLTestRunner`
2. kwargs for `xmlrunner.XMLTestRunner` is now generated in separate `get_test_runner_kwargs` method. It's made as in Django 1.11 but will work in Django 1.8 as well. Just follow naming convention. This was done mostly for code cleanup and separation.
3. Test for patch functionality added. It fails in pre-patch version and passes now. For this `mock` library was added in tox dependencies, hope it's ok.
4. Comments added across touched code.