### PR TITLE
Add an ISO-8601 timestamp to every testsuite and testcase in the XML-report

### DIFF
--- a/tests/builder_test.py
+++ b/tests/builder_test.py
@@ -83,6 +83,12 @@ class TestXMLContextTest(unittest.TestCase):
 
         element.attributes['time'].value
 
+    def test_add_timestamp_attribute_on_end_context(self):
+        self.root.begin('testsuite', 'name')
+        element = self.root.end()
+
+        element.attributes['timestamp'].value
+
 
 class TestXMLBuilderTest(unittest.TestCase):
     """TestXMLBuilder test cases.

--- a/xmlrunner/builder.py
+++ b/xmlrunner/builder.py
@@ -1,5 +1,6 @@
 import re
 import sys
+import datetime
 import time
 import six
 
@@ -80,6 +81,7 @@ class TestXMLContext(object):
         """
         self._stop_time = time.time()
         self.element.setAttribute('time', self.elapsed_time())
+        self.element.setAttribute('timestamp', self.timestamp())
         self._set_result_counters()
         return self.element
 
@@ -120,6 +122,11 @@ class TestXMLContext(object):
         `begin()` and `end()`, in seconds.
         """
         return format(self._stop_time - self._start_time, '.3f')
+
+    def timestamp(self):
+        """Returns the time the context ended as ISO-8601-formatted timestamp.
+        """
+        return datetime.datetime.fromtimestamp(self._stop_time).replace(microsecond=0).isoformat()
 
 
 class TestXMLBuilder(object):


### PR DESCRIPTION
To monitor when tests have last run, we read the timestamp attribute from JUnit-XML files. It would be nice if XML generated by XMLRunner included this timestamp attribute. 

This pull request adds timestamps to testsuites and testcases in the XML output. The timestamp attributes are ISO8601 as specified by the JUnit DTD included in the XMLRunner sources.