### PR TITLE
support empty skip reason

### DIFF
--- a/xmlrunner/result.py
+++ b/xmlrunner/result.py
@@ -96,7 +96,7 @@ class _TestInfo(object):
         self.outcome = outcome
         self.elapsed_time = 0
         self.timestamp = datetime.datetime.min.replace(microsecond=0).isoformat()
-        if err:
+        if err is not None:
             if self.outcome != _TestInfo.SKIP:
                 self.test_exception_name = safe_unicode(err[0].__name__)
                 self.test_exception_message = safe_unicode(err[1])


### PR DESCRIPTION
If the reason for skipping a test is an empty string, unittext-xml-reporting throws the following confusing exception. By checking that `err` is not `None` instead of just truthy adds support for empty reasons.

```
@unittest.skip('')
def test_something(...):
   pass
```

```
...
  File "/home/ubuntu/virtualenvs/venv-system/local/lib/python2.7/site-packages/xmlrunner/runner.py", line 112, in run
    result.generate_reports(self)
  File "/home/ubuntu/virtualenvs/venv-system/local/lib/python2.7/site-packages/xmlrunner/result.py", line 486, in generate_reports
    suite_name, tests, doc, parentElement, self.properties
  File "/home/ubuntu/virtualenvs/venv-system/local/lib/python2.7/site-packages/xmlrunner/result.py", line 367, in _report_testsuite
    _XMLTestResult._report_testcase(test, testsuite, xml_document)
  File "/home/ubuntu/virtualenvs/venv-system/local/lib/python2.7/site-packages/xmlrunner/result.py", line 451, in _report_testcase
    failure.setAttribute('message', test_result.test_exception_message)
AttributeError: '_TestInfo' object has no attribute 'test_exception_message'
```