### PR TITLE
Use own buffering mechanism to capture stdout / stderr for XML reports

### DIFF
--- a/xmlrunner/runner.py
+++ b/xmlrunner/runner.py
@@ -52,6 +52,7 @@ class XMLTestRunner(TextTestRunner):
             # Prepare the test execution
             result = self._make_result()
             result.failfast = self.failfast
+            result.buffer = self.buffer
             if hasattr(test, 'properties'):
                 # junit testsuite properties
                 result.properties = test.properties


### PR DESCRIPTION
The current implementation uses the unittest's `--buffer` option to capture stdout / stderr outputs from tests that is used in XML reports.
This results to suppress real-time console outputs from tests. It is often inconvenient.

This change introduces own buffering mechanism instead of the unittests's `--buffer` option.
