### PR TITLE
Make compatible with unittest.TestProgram in python3

### DIFF
--- a/xmlrunner/runner.py
+++ b/xmlrunner/runner.py
@@ -14,13 +14,11 @@ class XMLTestRunner(TextTestRunner):
     """
     A test runner class that outputs the results in JUnit like XML files.
     """
-    def __init__(self, output='.', outsuffix=None, stream=sys.stderr,
-                 descriptions=True, verbosity=1, elapsed_times=True,
-                 failfast=False, buffer=False, encoding=UTF8,
-                 resultclass=None):
-        TextTestRunner.__init__(self, stream, descriptions, verbosity,
-                                failfast=failfast, buffer=buffer)
-        self.verbosity = verbosity
+    def __init__(self, output='.', outsuffix=None, 
+                 elapsed_times=True, encoding=UTF8,
+                 resultclass=None,
+                 **kwargs):
+        super(XMLTestRunner, self).__init__(**kwargs)
         self.output = output
         self.encoding = encoding
         # None means default timestamped suffix


### PR DESCRIPTION
Replaces #140.

`XMLTestRunner` doesn't receive options like `-b` via unittest.TestProgram in python3.
This is caused for this implementation in `unittest` in python3: https://github.com/python/cpython/blob/v3.4.8/Lib/unittest/main.py#L234
`XMLTestRunner.__init__` should be compatible with `TestTestRunner.__init__`.

- [x] Add tests to demonstrate the issue. This will verify that the issue is fixed with this request
- [x] Fix the issue