### PR TITLE
Separate output for each test

### DIFF
--- a/tests/testsuite.py
+++ b/tests/testsuite.py
@@ -217,10 +217,10 @@ class XMLTestRunnerTestCase(unittest.TestCase):
         runner.run(suite)
         outdir.seek(0)
         output = outdir.read()
-        self.assertIn('classname="tests.testsuite.XMLTestRunnerTestCase.DummyTest" '
+        self.assertIn('classname="tests.testsuite.DummyTest" '
                       'name="test_pass"'.encode('utf8'),
                       output)
-        self.assertIn('classname="tests.testsuite.XMLTestRunnerTestCase.DummySubTest" '
+        self.assertIn('classname="tests.testsuite.DummySubTest" '
                       'name="test_subTest_pass"'.encode('utf8'),
                       output)
 
@@ -424,11 +424,11 @@ class XMLTestRunnerTestCase(unittest.TestCase):
         outdir.seek(0)
         output = outdir.read()
         self.assertIn(
-            b'<testcase classname="tests.testsuite.XMLTestRunnerTestCase.DummySubTest" '
+            b'<testcase classname="tests.testsuite.DummySubTest" '
             b'name="test_subTest_fail (i=0)"',
             output)
         self.assertIn(
-            b'<testcase classname="tests.testsuite.XMLTestRunnerTestCase.DummySubTest" '
+            b'<testcase classname="tests.testsuite.DummySubTest" '
             b'name="test_subTest_fail (i=1)"',
             output)
 

--- a/xmlrunner/runner.py
+++ b/xmlrunner/runner.py
@@ -16,7 +16,7 @@ class XMLTestRunner(TextTestRunner):
     """
     def __init__(self, output='.', outsuffix=None, 
                  elapsed_times=True, encoding=UTF8,
-                 resultclass=None,
+                 resultclass=None, per_test_output=False,
                  **kwargs):
         super(XMLTestRunner, self).__init__(**kwargs)
         self.output = output
@@ -31,6 +31,7 @@ class XMLTestRunner(TextTestRunner):
             self.resultclass = _XMLTestResult
         else:
             self.resultclass = resultclass
+        self.per_test_output = per_test_output
 
     def _make_result(self):
         """
@@ -39,7 +40,7 @@ class XMLTestRunner(TextTestRunner):
         """
         # override in subclasses if necessary.
         return self.resultclass(
-            self.stream, self.descriptions, self.verbosity, self.elapsed_times
+            self.stream, self.descriptions, self.verbosity, self.elapsed_times, self.per_test_output
         )
 
     def run(self, test):


### PR DESCRIPTION
Added per_test_output option to XMLTestRunner.
It enables creation of <system-out> and <system-err> node for each test, not for whole testsuite.
This is 100% compatible with jenkins junit xml format.

Probably there is not enough unittests for my change.
I can write them, but firstly I want to receive some input about changes in code.