### PR TITLE
Fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,18 @@ matrix:
       env: TOXENV=py27-djangocurr
     - python: "2.7"
       env: TOXENV=quality
-    - python: "3.3"
-      env: TOXENV=py33
     - python: "3.4"
       env: TOXENV=py34
+    - python: "3.5"
+      env: TOXENV=py35
+    - python: "3.6"
+      env: TOXENV=py36
+    - python: "3.7-dev"
+      env: TOXENV=py37
     - python: "pypy"
       env: TOXENV=pypy
+    - python: "pypy3"
+      env: TOXENV=pypy3
 
 install:
   - pip install tox codecov coveralls

--- a/tests/django_test.py
+++ b/tests/django_test.py
@@ -4,7 +4,10 @@ import sys
 import os
 from os import path
 import glob
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import tempfile
 import shutil
 

--- a/tests/testsuite.py
+++ b/tests/testsuite.py
@@ -204,12 +204,15 @@ class XMLTestRunnerTestCase(unittest.TestCase):
         runner.run(suite)
         outdir.seek(0)
         output = outdir.read()
-        self.assertIn('classname="tests.testsuite.DummyTest" '
-                      'name="test_pass"'.encode('utf8'),
-                      output)
-        self.assertIn('classname="tests.testsuite.DummySubTest" '
-                      'name="test_subTest_pass"'.encode('utf8'),
-                      output)
+        self.assertRegexpMatches(
+            output,
+            r'classname="tests\.testsuite\.(XMLTestRunnerTestCase\.)?'
+            r'DummyTest" name="test_pass"'.encode('utf8'),
+        )
+        self.assertRegexpMatches(
+            output,
+            r'classname="tests\.testsuite\.(XMLTestRunnerTestCase\.)?'
+            r'DummySubTest" name="test_subTest_pass"'.encode('utf8'))
 
     def test_xmlrunner_non_ascii(self):
         suite = unittest.TestSuite()
@@ -397,14 +400,16 @@ class XMLTestRunnerTestCase(unittest.TestCase):
         runner.run(suite)
         outdir.seek(0)
         output = outdir.read()
-        self.assertIn(
-            b'<testcase classname="tests.testsuite.DummySubTest" '
-            b'name="test_subTest_fail (i=0)"',
-            output)
-        self.assertIn(
-            b'<testcase classname="tests.testsuite.DummySubTest" '
-            b'name="test_subTest_fail (i=1)"',
-            output)
+        self.assertRegexpMatches(
+            output,
+            br'<testcase classname="tests\.testsuite\.'
+            br'(XMLTestRunnerTestCase\.)?DummySubTest" '
+            br'name="test_subTest_fail \(i=0\)"')
+        self.assertRegexpMatches(
+            output,
+            br'<testcase classname="tests\.testsuite\.'
+            br'(XMLTestRunnerTestCase\.)?DummySubTest" '
+            br'name="test_subTest_fail \(i=1\)"')
 
     @unittest.skipIf(not hasattr(unittest.TestCase, 'subTest'),
                      'unittest.TestCase.subTest not present.')

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,12 @@
 [tox]
-envlist = begin,py{27,py,33,34},py27-django{lts,curr},end,quality
+envlist = begin,py{27,py,py3,34,35,36,37},py27-django{lts,curr},end,quality
 
 [tox:travis]
 2.7 = begin,py27,py27-django{lts,curr},end,quality
-3.3 = py33
 3.4 = py34
+3.5 = py35
+3.6 = py36
+3.7 = py37
 
 [testenv]
 deps =


### PR DESCRIPTION
This PR fixes the tests by removing Python 3.3 from the Travis & Tox setup, and adds Python 3.5 and later while at it.