### PR TITLE
runner: reinstate all unittest arguments; add --output

### DIFF
--- a/tests/testsuite.py
+++ b/tests/testsuite.py
@@ -23,6 +23,11 @@ from lxml import etree
 import os
 import os.path
 
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 
 def _load_schema():
     path = os.path.join(os.path.dirname(__file__),
@@ -699,3 +704,27 @@ class DuplicateWriterTestCase(unittest.TestCase):
         self.writer.flush()
         self.assertEqual(self.getFirstContent(), self.getSecondContent())
         self.assertEqual(wrote, len(self.getSecondContent()))
+
+
+@unittest.skipIf(sys.version_info[0] < 3, 'Python 3 required')
+class XMLProgramTestCase(unittest.TestCase):
+    @mock.patch('sys.argv', ['xmlrunner', '-o', 'flaf'])
+    @mock.patch('xmlrunner.runner.XMLTestRunner')
+    @mock.patch('sys.exit')
+    def test_xmlrunner_output(self, exiter, testrunner):
+        xmlrunner.runner.XMLTestProgram()
+
+        kwargs = dict(
+            buffer=False,
+            failfast=False,
+            verbosity=1,
+            warnings='default',
+            output='flaf',
+        )
+
+        if sys.version_info[:2] > (3, 4):
+            kwargs.update(tb_locals=False)
+
+        testrunner.assert_called_once_with(**kwargs)
+
+        exiter.assert_called_once_with(False)

--- a/xmlrunner/__main__.py
+++ b/xmlrunner/__main__.py
@@ -1,8 +1,7 @@
 """Main entry point"""
 
 import sys
-from .unittest import TestProgram
-from .runner import XMLTestRunner
+from .runner import XMLTestProgram
 
 if sys.argv[0].endswith("__main__.py"):
     import os.path
@@ -17,9 +16,4 @@ if sys.argv[0].endswith("__main__.py"):
 __unittest = True
 
 
-main = TestProgram
-
-main(
-    module=None, testRunner=XMLTestRunner,
-    # see issue #59
-    failfast=False, catchbreak=False, buffer=False)
+XMLTestProgram(module=None)


### PR DESCRIPTION
I tested with Python 2.7, 3.5 and 3.7, and at least --buffer works
everywhere. I was also missing a way to specify the output directory,
so I added the ability to do so.

This fixes #143 and closes #144.

(Please note that the change doesn't affect Python 2.7 as it uses a different approach to parsing arguments.)