### PR TITLE
Enable XMLTestRunner to make TestResults for in-memory usage

### DIFF
--- a/xmlrunner/runner.py
+++ b/xmlrunner/runner.py
@@ -105,6 +105,10 @@ class XMLTestRunner(TextTestRunner):
             else:
                 self.stream.write("\n")
 
+            if self.output is None:
+                self.stream.writeln()
+                self.stream.writeln('NOT generating XML reports')
+            else:
             # Generate reports
             self.stream.writeln()
             self.stream.writeln('Generating XML reports...')

--- a/xmlrunner/runner.py
+++ b/xmlrunner/runner.py
@@ -109,10 +109,10 @@ class XMLTestRunner(TextTestRunner):
                 self.stream.writeln()
                 self.stream.writeln('NOT generating XML reports')
             else:
-            # Generate reports
-            self.stream.writeln()
-            self.stream.writeln('Generating XML reports...')
-            result.generate_reports(self)
+                # Generate reports
+                self.stream.writeln()
+                self.stream.writeln('Generating XML reports...')
+                result.generate_reports(self)
         finally:
             pass
 


### PR DESCRIPTION
Hi!

First, I want to be very clear that half the reason I'm offering this PR is to practice doing PRs.  While I do think it may be useful to other people it definitely takes the XMLTestRunner in a new direction and so please do feel free to reject this :)

The goal is to have a test runner that can generate a complete TestResult object/tree, and then hand that TestResult off to something else to process (instead of forcing the 'something else' to consume XML from a file written to the local filesystem).

I was thinking about using the unittest.TextTestRunner class, but that one doesn't list the successful test runs.  XMLTestRunner _does_ list the successes, which makes it a bit better for what I wanted it for.

**The Change:** By setting the .output field to None the XMLTestRunner will still run all the tests but _not_ generate the XML output, leaving client software to access the awesomely thorough TestResult purely in-memory, instead.

