### PR TITLE
Include output in passing tests; fix expected failures; adjust verbose output

### DIFF
--- a/tests/testsuite.py
+++ b/tests/testsuite.py
@@ -185,8 +185,9 @@ class XMLTestRunnerTestCase(unittest.TestCase):
         self.runner_kwargs = {}
         self.addCleanup(rmtree, self.outdir)
 
-    def _test_xmlrunner(self, suite, runner=None):
-        outdir = self.outdir
+    def _test_xmlrunner(self, suite, runner=None, outdir=None):
+        if outdir is None:
+            outdir = self.outdir
         stream = self.stream
         verbosity = self.verbosity
         runner_kwargs = self.runner_kwargs
@@ -194,9 +195,15 @@ class XMLTestRunnerTestCase(unittest.TestCase):
             runner = xmlrunner.XMLTestRunner(
                 stream=stream, output=outdir, verbosity=verbosity,
                 **runner_kwargs)
-        self.assertEqual(0, len(glob(os.path.join(outdir, '*xml'))))
+        if isinstance(outdir, BytesIO):
+            self.assertFalse(outdir.getvalue())
+        else:
+            self.assertEqual(0, len(glob(os.path.join(outdir, '*xml'))))
         runner.run(suite)
-        self.assertEqual(1, len(glob(os.path.join(outdir, '*xml'))))
+        if isinstance(outdir, BytesIO):
+            self.assertTrue(outdir.getvalue())
+        else:
+            self.assertEqual(1, len(glob(os.path.join(outdir, '*xml'))))
         return runner
 
     def test_basic_unittest_constructs(self):

--- a/xmlrunner/result.py
+++ b/xmlrunner/result.py
@@ -391,7 +391,7 @@ class _XMLTestResult(_TextTestResult):
         """
         self._save_output_data()
 
-        testinfo = self.infoclass(self, test, self.infoclass.ERROR, err)
+        testinfo = self.infoclass(self, test, self.infoclass.SKIP, err)
         testinfo.test_exception_name = 'XFAIL'
         testinfo.test_exception_message = 'expected failure: {}'.format(testinfo.test_exception_message)
 

--- a/xmlrunner/result.py
+++ b/xmlrunner/result.py
@@ -313,7 +313,7 @@ class _XMLTestResult(_TextTestResult):
         """
         self._save_output_data()
         self._prepare_callback(
-            self.infoclass(self, test), self.successes, 'OK', '.'
+            self.infoclass(self, test), self.successes, 'ok', '.'
         )
 
     @failfast
@@ -380,8 +380,10 @@ class _XMLTestResult(_TextTestResult):
         self._save_output_data()
         testinfo = self.infoclass(
             self, test, self.infoclass.SKIP, reason)
+        testinfo.test_exception_name = 'skip'
+        testinfo.test_exception_message = reason
         self.skipped.append((testinfo, reason))
-        self._prepare_callback(testinfo, [], 'SKIP', 'S')
+        self._prepare_callback(testinfo, [], 'skip', 's')
 
     def addExpectedFailure(self, test, err):
         """
@@ -390,11 +392,11 @@ class _XMLTestResult(_TextTestResult):
         self._save_output_data()
 
         testinfo = self.infoclass(self, test, self.infoclass.ERROR, err)
-        testinfo.test_exception_name = 'ExpectedFailure'
-        testinfo.test_exception_message = 'EXPECTED FAILURE: {}'.format(testinfo.test_exception_message)
+        testinfo.test_exception_name = 'XFAIL'
+        testinfo.test_exception_message = 'expected failure: {}'.format(testinfo.test_exception_message)
 
         self.expectedFailures.append((testinfo, self._exc_info_to_string(err, test)))
-        self._prepare_callback(testinfo, [], 'EXPECTED FAILURE', 'X')
+        self._prepare_callback(testinfo, [], 'expected failure', 'x')
 
     @failfast
     def addUnexpectedSuccess(self, test):
@@ -407,11 +409,11 @@ class _XMLTestResult(_TextTestResult):
         testinfo.outcome = self.infoclass.ERROR
         # But since we want to have error outcome, we need to provide additional fields:
         testinfo.test_exception_name = 'UnexpectedSuccess'
-        testinfo.test_exception_message = ('UNEXPECTED SUCCESS: This test was marked as expected failure but passed, '
+        testinfo.test_exception_message = ('Unexpected success: This test was marked as expected failure but passed, '
                                            'please review it')
 
-        self.unexpectedSuccesses.append(testinfo)
-        self._prepare_callback(testinfo, [], 'UNEXPECTED SUCCESS', 'U')
+        self.unexpectedSuccesses.append((testinfo, 'unexpected success'))
+        self._prepare_callback(testinfo, [], 'unexpected success', 'u')
 
     def printErrorList(self, flavour, errors):
         """


### PR DESCRIPTION
This PR adjust expected failures to be reported as skips, includes output in successful tests and makes the verbose output more consistent with `unittest`.
