### PR TITLE
Correctly handle partial test methods in startTest.

### DIFF
--- a/tests/testsuite.py
+++ b/tests/testsuite.py
@@ -720,6 +720,25 @@ class XMLTestRunnerTestCase(unittest.TestCase):
         self.assertIn('should be printed', r[0].getvalue())
         self.assertNotIn('should be printed', r[1].getvalue())
 
+    def test_partialmethod(self):
+        try:
+            from functools import partialmethod
+        except ImportError:
+            raise unittest.SkipTest('functools.partialmethod is not available.')
+        def test_partialmethod(test):
+            pass
+        class TestWithPartialmethod(unittest.TestCase):
+            pass
+        setattr(
+            TestWithPartialmethod,
+            'test_partialmethod',
+            partialmethod(test_partialmethod),
+        )
+        suite = unittest.TestSuite()
+        suite.addTest(TestWithPartialmethod('test_partialmethod'))
+        self._test_xmlrunner(suite)
+
+
 
 class DuplicateWriterTestCase(unittest.TestCase):
     def setUp(self):

--- a/xmlrunner/result.py
+++ b/xmlrunner/result.py
@@ -272,6 +272,8 @@ class _XMLTestResult(_TextTestResult):
                 test_class = type(test)
                 # Note: inspect can get confused with decorators, so use class.
                 self.filename = inspect.getsourcefile(test_class)
+                # Handle partial and partialmethod objects.
+                test_method = getattr(test_method, 'func', test_method)
                 _, self.lineno = inspect.getsourcelines(test_method)
         finally:
             pass


### PR DESCRIPTION
Deals with https://github.com/xmlrunner/unittest-xml-reporting/commit/4890cd7ca3ccfcd8fc881f0cdd1d257efe5f5e5f#r32781252