### PR TITLE
Use 'utf-8' encoding for exception info if there is no encoding set for sys.stdout

### DIFF
--- a/xmlrunner/result.py
+++ b/xmlrunner/result.py
@@ -693,6 +693,8 @@ class _XMLTestResult(_TextTestResult):
                 msgLines.append(STDERR_LINE % error)
         # This is the extra magic to make sure all lines are str
         encoding = getattr(sys.stdout, 'encoding', 'utf-8')
+        if encoding is None:
+            encoding = 'utf-8'
         lines = []
         for line in msgLines:
             if not isinstance(line, str):


### PR DESCRIPTION
On some systems encoding for sys.stdout is defined but is None. In this case the default utf-8 is not used as getattr() will find the attrbute but because it is None, we get an exception when we try to encode a line.