### PR TITLE
Fix crash when exceptions contain unicode in buffered output

### DIFF
--- a/tests/testsuite.py
+++ b/tests/testsuite.py
@@ -370,13 +370,19 @@ class XMLTestRunnerTestCase(unittest.TestCase):
                       output)
 
     def test_xmlrunner_non_ascii_failures(self):
+        self._xmlrunner_non_ascii_failures()
+
+    def test_xmlrunner_non_ascii_failures_buffered_output(self):
+        self._xmlrunner_non_ascii_failures(buffer=True)
+
+    def _xmlrunner_non_ascii_failures(self, buffer=False):
         suite = unittest.TestSuite()
         suite.addTest(self.DummyTest(
             'test_non_ascii_runner_buffer_output_fail'))
         outdir = BytesIO()
         runner = xmlrunner.XMLTestRunner(
             stream=self.stream, output=outdir, verbosity=self.verbosity,
-            **self.runner_kwargs)
+            buffer=buffer, **self.runner_kwargs)
 
         # allow output non-ascii letters to stdout
         orig_stdout = sys.stdout

--- a/xmlrunner/result.py
+++ b/xmlrunner/result.py
@@ -693,6 +693,9 @@ class _XMLTestResult(_TextTestResult):
                 msgLines.append(STDERR_LINE % error)
         # This is the extra magic to make sure all lines are str
         encoding = getattr(sys.stdout, 'encoding', 'utf-8')
+        if encoding is None:
+            encoding = 'utf-8'
+
         lines = []
         for line in msgLines:
             if not isinstance(line, str):


### PR DESCRIPTION
When `xmlrunner.XMLTestRunner` is run in buffered mode,
`sys.stdout` points to StringIO instance. It has `encoding`
attribute, but it is set to `None` which causes a crash during
the test run in Python 2:

    Traceback (most recent call last):
      File "/home/miika/apps/unittest-xml-reporting/tests/testsuite.py", line 376, in test_xmlrunner_non_ascii_failures_buffered_output
        self._xmlrunner_non_ascii_failures(buffer=True)
      File "/home/miika/apps/unittest-xml-reporting/tests/testsuite.py", line 398, in _xmlrunner_non_ascii_failures
        runner.run(suite)
      File "/home/miika/apps/unittest-xml-reporting/xmlrunner/runner.py", line 70, in run
        test(result)
      File "/usr/lib/python2.7/unittest/suite.py", line 70, in __call__
        return self.run(*args, **kwds)
      File "/usr/lib/python2.7/unittest/suite.py", line 108, in run
        test(result)
      File "/usr/lib/python2.7/unittest/case.py", line 393, in __call__
        return self.run(*args, **kwds)
      File "/usr/lib/python2.7/unittest/case.py", line 333, in run
        result.addFailure(self, sys.exc_info())
      File "/usr/lib/python2.7/unittest/result.py", line 19, in inner
        return method(self, *args, **kw)
      File "/home/miika/apps/unittest-xml-reporting/xmlrunner/result.py", line 344, in addFailure
        self, test, self.infoclass.FAILURE, err)
      File "/home/miika/apps/unittest-xml-reporting/xmlrunner/result.py", line 163, in __init__
        err, test_method)
      File "/home/miika/apps/unittest-xml-reporting/xmlrunner/result.py", line 703, in _exc_info_to_string
        line = line.encode(encoding)
    TypeError: encode() argument 1 must be string, not None

Fixes https://github.com/xmlrunner/unittest-xml-reporting/issues/200