### PR TITLE
Avoid including empty system-out and system-err when reporting testcases

### DIFF
--- a/xmlrunner/result.py
+++ b/xmlrunner/result.py
@@ -591,13 +591,13 @@ class _XMLTestResult(_TextTestResult):
                 _XMLTestResult._createCDATAsections(
                     xml_document, result_elem, error_info)
 
-        if test_result.stdout is not None:
+        if test_result.stdout:
             systemout = xml_document.createElement('system-out')
             testcase.appendChild(systemout)
             _XMLTestResult._createCDATAsections(
                 xml_document, systemout, test_result.stdout)
 
-        if test_result.stderr is not None:
+        if test_result.stderr:
             systemout = xml_document.createElement('system-err')
             testcase.appendChild(systemout)
             _XMLTestResult._createCDATAsections(


### PR DESCRIPTION
This PR removes the empty stdout/stderr in XML test report output.

Output before:

```
<testcase classname="MyTestClass" name="test_my_test_name" time="0.000" timestamp="2020-04-12T16:01:18" file="test_the_xml_output.py" line="61">
    <system-out><![CDATA[]]></system-out>
    <system-err><![CDATA[]]></system-err>
</testcase>
```

Output now:

```
<testcase classname="MyTestClass" name="test_my_test_name" time="0.000" timestamp="2020-04-12T16:01:18" file="test_the_xml_output.py" line="61"/>
```
