### PR TITLE
Circumvent freezegun in favor of a real clock where possible

### DIFF
--- a/tests/builder_test.py
+++ b/tests/builder_test.py
@@ -4,8 +4,10 @@ from xmlrunner.unittest import unittest
 
 import xml.etree.ElementTree as ET
 from xml.dom.minidom import Document
+from freezegun import freeze_time
 
 from xmlrunner import builder
+import time
 
 
 class TestXMLContextTest(unittest.TestCase):
@@ -88,6 +90,19 @@ class TestXMLContextTest(unittest.TestCase):
 
         element.attributes['timestamp'].value
 
+    @freeze_time('2012-12-21')
+    def test_time_and_timestamp_attributes_are_not_affected_by_freezegun(self):
+        self.root.begin('testsuite', 'name')
+        time.sleep(.015)
+        element = self.root.end()
+
+        current_year = int(element.attributes['timestamp'].value[:4])
+        self.assertGreater(current_year, 2012)
+        self.assertLess(current_year, 2100)
+
+        current_time = float(element.attributes['time'].value)
+        self.assertGreater(current_time, .012)
+        self.assertLess(current_time, .020)
 
 class TestXMLBuilderTest(unittest.TestCase):
     """TestXMLBuilder test cases.

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ deps =
     djangocurr: django>=2.2.0
     pytest: pytest
     lxml>=3.6.0
+    freezegun
 commands =
     coverage run --append setup.py test
     coverage report --omit='.tox/*'

--- a/xmlrunner/builder.py
+++ b/xmlrunner/builder.py
@@ -1,9 +1,10 @@
 import re
 import sys
 import datetime
-import time
 
 from xml.dom.minidom import Document
+
+from .time import get_real_time_if_possible
 
 
 __all__ = ('TestXMLBuilder', 'TestXMLContext')
@@ -72,13 +73,13 @@ class TestXMLContext(object):
         """
         self.element = self.xml_doc.createElement(tag)
         self.element.setAttribute('name', replace_nontext(name))
-        self._start_time = time.time()
+        self._start_time = get_real_time_if_possible()
 
     def end(self):
         """Closes this context (started with a call to `begin`) and creates an
         attribute for each counter and another for the elapsed time.
         """
-        self._stop_time = time.time()
+        self._stop_time = get_real_time_if_possible()
         self.element.setAttribute('time', self.elapsed_time())
         self.element.setAttribute('timestamp', self.timestamp())
         self._set_result_counters()

--- a/xmlrunner/result.py
+++ b/xmlrunner/result.py
@@ -9,9 +9,7 @@ import re
 from os import path
 from io import StringIO
 
-# use direct import to bypass freezegun
-from time import time
-
+from .time import get_real_time_if_possible
 from .unittest import TestResult, _TextTestResult, failfast
 
 
@@ -253,7 +251,7 @@ class _XMLTestResult(_TextTestResult):
         """
         Called before execute each test method.
         """
-        self.start_time = time()
+        self.start_time = get_real_time_if_possible()
         TestResult.startTest(self, test)
 
         try:
@@ -321,7 +319,8 @@ class _XMLTestResult(_TextTestResult):
         # self._stderr_data = sys.stderr.getvalue()
 
         _TextTestResult.stopTest(self, test)
-        self.stop_time = time()
+
+        self.stop_time = get_real_time_if_possible()
 
         if self.callback and callable(self.callback):
             self.callback()

--- a/xmlrunner/runner.py
+++ b/xmlrunner/runner.py
@@ -1,8 +1,10 @@
 
 import argparse
 import sys
+
 import time
 
+from .time import get_real_time_if_possible
 from .unittest import TextTestRunner, TestProgram
 from .result import _XMLTestResult
 
@@ -15,7 +17,7 @@ class XMLTestRunner(TextTestRunner):
     """
     A test runner class that outputs the results in JUnit like XML files.
     """
-    def __init__(self, output='.', outsuffix=None, 
+    def __init__(self, output='.', outsuffix=None,
                  elapsed_times=True, encoding=UTF8,
                  resultclass=None,
                  **kwargs):
@@ -62,9 +64,9 @@ class XMLTestRunner(TextTestRunner):
             self.stream.writeln(result.separator2)
 
             # Execute tests
-            start_time = time.time()
+            start_time = get_real_time_if_possible()
             test(result)
-            stop_time = time.time()
+            stop_time = get_real_time_if_possible()
             time_taken = stop_time - start_time
 
             # Print results

--- a/xmlrunner/time.py
+++ b/xmlrunner/time.py
@@ -1,0 +1,15 @@
+"""Timing function that will attempt to circumvent freezegun and other common
+techniques of mocking time in Python unit tests; will only succeed at this on
+Unix currently. Falls back to regular time.time().
+"""
+
+import time
+
+def get_real_time_if_possible():
+    if hasattr(time, 'clock_gettime'):
+        try:
+            return time.clock_gettime(time.CLOCK_REALTIME)
+        except OSError:
+            # would occur if time.CLOCK_REALTIME is not available, for example
+            pass
+    return time.time()


### PR DESCRIPTION
Hi,

First off, thank you for this wonderful tool! At my work we've been using it to get [CircleCI's Test Summary feature](https://circleci.com/docs/2.0/collect-test-data/) to display information about our test runs, and it's been awesome.

I noticed however that for certain test suites where we use [Freezegun](https://github.com/spulec/freezegun), the test runner reports a test runtime of 0.000s. I saw in [this comment](https://github.com/xmlrunner/unittest-xml-reporting/blob/7d0a0e7e946f5c44593f53dcc3cd24d641db93de/xmlrunner/result.py#L12) that some prior efforts have been made to circumvent `freezegun` in this project; unfortunately, this approach did not seem to work (at least, not in our case).

Following the pseudocode in [this pep](https://www.python.org/dev/peps/pep-0418/#time-time), I implemented a function that's typically equivalent to authentic `time.time()`, but unlike that function, is not mocked out by `freezegun`. This is now in `xmlrunner.time`, and used everywhere `time()` was previously called in this project. Where the [clock_gettime](https://docs.python.org/3/library/time.html#time.clock_gettime) call it depends on isn't available (mostly, non-Unix systems), or where there is no `CLOCK_REALTIME` available on the system, the new function will fall back to (possibly mocked) `time.time()`.

I also verified in unit tests of the builder and the runner that the resulting timestamps + elapsed time evaluations are accurate even for a test during which time is frozen with `freezegun` - this necessitated adding `freezegun` to the test env in `tox.ini`.

`tox -e pytest` works fine with the new tests; I apparently didn't have some of the interpreters running the tests with `tox` requires, so that command failed for me locally, but I expect there won't be issues on a properly prepared system.