### PR TITLE
Add outsuffix option

### DIFF
--- a/tests/testsuite.py
+++ b/tests/testsuite.py
@@ -989,6 +989,27 @@ class XMLProgramTestCase(unittest.TestCase):
         testrunner.assert_called_once_with(**kwargs)
         exiter.assert_called_once_with(False)
 
+    @mock.patch('sys.argv', ['xmlrunner', '--outsuffix', ''])
+    @mock.patch('xmlrunner.runner.open')
+    @mock.patch('xmlrunner.runner.XMLTestRunner')
+    @mock.patch('sys.exit')
+    def test_xmlrunner_outsuffix(self, exiter, testrunner, opener):
+        xmlrunner.runner.XMLTestProgram()
+
+        kwargs = dict(
+            buffer=mock.ANY,
+            failfast=mock.ANY,
+            verbosity=mock.ANY,
+            warnings=mock.ANY,
+            outsuffix='',
+        )
+
+        if sys.version_info[:2] > (3, 4):
+            kwargs.update(tb_locals=mock.ANY)
+
+        testrunner.assert_called_once_with(**kwargs)
+        exiter.assert_called_once_with(False)
+
 
 class ResolveFilenameTestCase(unittest.TestCase):
     @mock.patch('os.path.relpath')

--- a/xmlrunner/runner.py
+++ b/xmlrunner/runner.py
@@ -15,7 +15,8 @@ class XMLTestRunner(TextTestRunner):
     """
     A test runner class that outputs the results in JUnit like XML files.
     """
-    def __init__(self, output='.', outsuffix=None, 
+
+    def __init__(self, output='.', outsuffix=None,
                  elapsed_times=True, encoding=UTF8,
                  resultclass=None,
                  **kwargs):
@@ -138,9 +139,13 @@ class XMLTestProgram(TestProgram):
         group.add_argument(
             '--output-file', metavar='FILENAME',
             help='Filename for storing XML report')
+        parser.add_argument(
+            '--outsuffix', metavar='STRING',
+            help='Output suffix (timestamp is default)')
         namespace, argv = parser.parse_known_args(argv)
         self.output = namespace.output
         self.output_file = namespace.output_file
+        self.outsuffix = namespace.outsuffix
         kwargs['argv'] = argv
 
     def _initArgParsers(self):
@@ -155,6 +160,9 @@ class XMLTestProgram(TestProgram):
             group.add_argument(
                 '--output-file', metavar='FILENAME', nargs=1,
                 help='Filename for storing XML report')
+            group.add_argument(
+                '--outsuffix', metavar='STRING', nargs=1,
+                help='Output suffix (timestamp is default)')
 
     def runTests(self):
         kwargs = dict(
@@ -173,6 +181,9 @@ class XMLTestProgram(TestProgram):
                 kwargs.update(output=output_file)
             elif self.output is not None:
                 kwargs.update(output=self.output)
+
+            if self.outsuffix is not None:
+                kwargs.update(outsuffix=self.outsuffix)
 
             self.testRunner = self.testRunner(**kwargs)
             super(XMLTestProgram, self).runTests()


### PR DESCRIPTION
I want to record test results without a datetime suffix. 
Because I need to send test results as the same name to use CircleCi's test in parallel (https://circleci.com/docs/2.0/parallelism-faster-jobs/#splitting-by-timing-data)

However, the xmlrunner adds a date-time suffix to a test suite automatically. Although there are the same test cases, the CircleCI realizes different test cases.

So I add an outsuffix option to control a suffix from the command.

e.g) 
```
xmlrunner --output ./test-results/  --outsuffix="" tests/**/test_*.py

$ xmlrunner -h
usage: xmlrunner [-h] [-o DIR | --output-file FILENAME] [--outsuffix STRING]

optional arguments:
  -h, --help            show this help message and exit
  -o DIR, --output DIR  Directory for storing XML reports ('.' default)
  --output-file FILENAME
                        Filename for storing XML report
  --outsuffix STRING    Output suffix (timestamp is default)
```

How about this option? Will you please review it?