### PR TITLE
Don't use aliases removed in Python 3.11.

### DIFF
--- a/tests/testsuite.py
+++ b/tests/testsuite.py
@@ -270,12 +270,12 @@ class XMLTestRunnerTestCase(unittest.TestCase):
             '//testcase': ('classname', 'name'),
             '//failure': ('message',),
         })
-        self.assertRegexpMatches(
+        self.assertRegex(
             output,
             r'classname="tests\.testsuite\.(XMLTestRunnerTestCase\.)?'
             r'DummyTest" name="test_pass"'.encode('utf8'),
         )
-        self.assertRegexpMatches(
+        self.assertRegex(
             output,
             r'classname="tests\.testsuite\.(XMLTestRunnerTestCase\.)?'
             r'DummySubTest" name="test_subTest_pass"'.encode('utf8'),
@@ -491,12 +491,12 @@ class XMLTestRunnerTestCase(unittest.TestCase):
             '//testcase': ('classname', 'name'),
             '//failure': ('message',),
         })
-        self.assertRegexpMatches(
+        self.assertRegex(
             output,
             br'<testcase classname="tests\.testsuite\.'
             br'(XMLTestRunnerTestCase\.)?DummySubTest" '
             br'name="test_subTest_fail \(i=0\)"')
-        self.assertRegexpMatches(
+        self.assertRegex(
             output,
             br'<testcase classname="tests\.testsuite\.'
             br'(XMLTestRunnerTestCase\.)?DummySubTest" '
@@ -520,12 +520,12 @@ class XMLTestRunnerTestCase(unittest.TestCase):
             '//testcase': ('classname', 'name'),
             '//failure': ('message',),
         })
-        self.assertRegexpMatches(
+        self.assertRegex(
             output,
             br'<testcase classname="tests\.testsuite\.'
             br'(XMLTestRunnerTestCase\.)?DummySubTest" '
             br'name="test_subTest_error \(i=0\)"')
-        self.assertRegexpMatches(
+        self.assertRegex(
             output,
             br'<testcase classname="tests\.testsuite\.'
             br'(XMLTestRunnerTestCase\.)?DummySubTest" '

--- a/xmlrunner/result.py
+++ b/xmlrunner/result.py
@@ -12,7 +12,7 @@ from io import StringIO
 # use direct import to bypass freezegun
 from time import time
 
-from .unittest import TestResult, _TextTestResult, failfast
+from .unittest import TestResult, TextTestResult, failfast
 
 
 # Matches invalid XML1.0 unicode characters, like control characters:
@@ -189,7 +189,7 @@ class _TestInfo(object):
         return self.test_exception_info
 
 
-class _XMLTestResult(_TextTestResult):
+class _XMLTestResult(TextTestResult):
     """
     A test result class that can express test results in a XML report.
 
@@ -197,7 +197,7 @@ class _XMLTestResult(_TextTestResult):
     """
     def __init__(self, stream=sys.stderr, descriptions=1, verbosity=1,
                  elapsed_times=True, properties=None, infoclass=None):
-        _TextTestResult.__init__(self, stream, descriptions, verbosity)
+        TextTestResult.__init__(self, stream, descriptions, verbosity)
         self._stdout_data = None
         self._stderr_data = None
         self._stdout_capture = StringIO()
@@ -320,7 +320,7 @@ class _XMLTestResult(_TextTestResult):
         # self._stdout_data = sys.stdout.getvalue()
         # self._stderr_data = sys.stderr.getvalue()
 
-        _TextTestResult.stopTest(self, test)
+        TextTestResult.stopTest(self, test)
         self.stop_time = time()
 
         if self.callback and callable(self.callback):

--- a/xmlrunner/unittest.py
+++ b/xmlrunner/unittest.py
@@ -5,11 +5,11 @@ import sys
 # pylint: disable-msg=W0611
 import unittest
 from unittest import TextTestRunner
-from unittest import TestResult, _TextTestResult
+from unittest import TestResult, TextTestResult
 from unittest.result import failfast
 from unittest.main import TestProgram
 
 
 __all__ = (
-    'unittest', 'TextTestRunner', 'TestResult', '_TextTestResult',
+    'unittest', 'TextTestRunner', 'TestResult', 'TextTestResult',
     'TestProgram', 'failfast')


### PR DESCRIPTION
See https://github.com/python/cpython/commit/b0a6ede3d0bd6fa4ffe413ab4dfc1059201df25b.