### PR TITLE
Add time zone to reported timestamp

### DIFF
--- a/xmlrunner/builder.py
+++ b/xmlrunner/builder.py
@@ -130,7 +130,7 @@ class TestXMLContext(object):
     def timestamp(self):
         """Returns the time the context ended as ISO-8601-formatted timestamp.
         """
-        return datetime.datetime.fromtimestamp(self._stop_time).replace(microsecond=0).isoformat()
+        return datetime.datetime.fromtimestamp(self._stop_time).replace(microsecond=0).astimezone().isoformat()
 
 
 class TestXMLBuilder(object):


### PR DESCRIPTION
When used on a timezone-unaware `datetime`, Python's `datetime.isoformat()` method produces a timestamp without a timezone designator. While this is technically allowed by ISO8601, many ISO8601 parsers expect a timezone designator of some sort. 

This PR adds an `astimezone()` call before creating the timestamp. When used on a timezone-unaware `datetime` (as the one here is), it will assume the `datetime` is relative to the system timezone and append that to the timestamp. This is the correct behavior in this instance.

This change will probably be a no-op for most people, as `fromisoformat()` and other ISO8601-compliant parsers will parse the new timestamp just fine. This change would be a breaking change for anyone relying on the timestamp to be timezone-unaware.

Please let me know if you have ideas for testing! We use `xmlrunner` in PyTorch in our CI, and our CI runners are all over the place geographically, so it would be useful for us to have a timezone-aware timestamp.
