### PR TITLE
Adding support for startTestRun and stopTestRun

### DIFF
--- a/tests/testsuite.py
+++ b/tests/testsuite.py
@@ -318,6 +318,33 @@ class XMLTestRunnerTestCase(unittest.TestCase):
             u'message="demonstrating non-ascii skipping: éçà"'.encode('utf8'),
             output)
 
+    def test_start_and_stop_test(self):
+        def startTestRun(self):
+            self.stream.writeln('startTestRun called')
+        def stopTestRun(self):
+            self.stream.writeln('stopTestRun called')
+
+        suite = unittest.TestSuite()
+        suite.addTest(self.DummyTest('test_pass'))
+        outdir = BytesIO()
+        runner = xmlrunner.XMLTestRunner(
+            stream=self.stream, output=outdir, verbosity=self.verbosity,
+            **self.runner_kwargs)
+        old_test_run_start = unittest.result.TestResult.startTestRun
+        old_test_run_stop = unittest.result.TestResult.stopTestRun
+        unittest.result.TestResult.startTestRun = startTestRun
+        unittest.result.TestResult.stopTestRun = stopTestRun
+        try:
+            runner.run(suite)
+            outdir.seek(0)
+            output = outdir.read()
+            testsuite_output = self.stream.getvalue()
+            self.assertIn('startTestRun called',testsuite_output)
+            self.assertIn('stopTestRun called',testsuite_output)
+        finally:
+            unittest.result.TestResult.startTestRun = old_test_run_start
+            unittest.result.TestResult.stopTestRun = old_test_run_stop
+
     def test_xmlrunner_safe_xml_encoding_name(self):
         suite = unittest.TestSuite()
         suite.addTest(self.DummyTest('test_pass'))

--- a/xmlrunner/runner.py
+++ b/xmlrunner/runner.py
@@ -64,7 +64,15 @@ class XMLTestRunner(TextTestRunner):
 
             # Execute tests
             start_time = time.monotonic()
-            test(result)
+            startTestRun = getattr(result, 'startTestRun', None)
+            if startTestRun is not None:
+                startTestRun()
+            try:
+                test(result)
+            finally:
+                stopTestRun = getattr(result, 'stopTestRun', None)
+                if stopTestRun is not None:
+                    stopTestRun()
             stop_time = time.monotonic()
             time_taken = stop_time - start_time
 


### PR DESCRIPTION
Hi,
I wanted to add support for startTestRun and stopTestRun into xmlrunner.
We use startTestRun and stopTestRun in our CI tests as we have expensive setup and tear down that we only want to do once. My understanding from https://docs.python.org/3/library/unittest.html is that these functions have been available since version 3.1 of unittest.
For this change, I've looked at the source of unittest and tried to make exactly the same changes to xmlrunner.
I've added a test to the test suite to cover this functionality.