### PR TITLE
setup.py: drop data_files, installs LICENSE to incorrect place

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
     description = 'unittest-based test runner with Ant/JUnit like XML reporting.',
     long_description = long_description,
     long_description_content_type = 'text/markdown',
-    data_files = [('', ['LICENSE'])],
     install_requires = ['lxml'],
     license = 'BSD',
     platforms = ['Any'],


### PR DESCRIPTION
As reported in issue
https://github.com/xmlrunner/unittest-xml-reporting/issues/284, the data_files statement in the setup() calls installs the LICENSE file in the wrong place: in /usr/LICENSE, or even /LICENSE depending on the configuration.

So let's drop this, and let setuptools install the LICENSE file automatically: since setuptools v56, the license_files attribute is automatically assigned to a default value, which includes "LICENSE", so there is in fact nothing to do to the get the LICENSE file installed at the correct location. See
https://setuptools.pypa.io/en/latest/history.html#v56-0-0.