### PR TITLE
[Feature] Add hostname in testsuite report

### DIFF
--- a/xmlrunner/result.py
+++ b/xmlrunner/result.py
@@ -1,6 +1,7 @@
 
 import inspect
 import io
+import platform
 import os
 import sys
 import datetime
@@ -503,6 +504,11 @@ class _XMLTestResult(TextTestResult):
             testsuite.setAttribute(
                 'timestamp', max(map(lambda e: e.timestamp, tests))
             )
+        
+        testsuite.setAttribute(
+            'hostname', platform.node()
+        )
+
         failures = filter(lambda e: e.outcome == e.FAILURE, tests)
         testsuite.setAttribute('failures', str(len(list(failures))))
 


### PR DESCRIPTION
For certain use cases, it is very helpful to have the hostname of the workstation that ran the testsuite. Therefore this PR propose a simple addition to add the `hostname` field of the `testsuite` XML section.