### PR TITLE
Overwrite `encoding` property in `_DuplicateWriter`

### DIFF
--- a/xmlrunner/result.py
+++ b/xmlrunner/result.py
@@ -91,6 +91,10 @@ class _DuplicateWriter(io.TextIOBase):
         self._first = first
         self._second = second
 
+    @property
+    def encoding(self):
+        return self._first.encoding
+
     def flush(self):
         self._first.flush()
         self._second.flush()


### PR DESCRIPTION
`_DuplicateWriter` wraps `sys.stdout` and applications might expect the encoding being set to a "real" value to determine the encoding to use.

However `_DuplicateWriter` never sets it so the property defaults to `None`.    As that class is basically a wrapper around its `first` stream it should forward the encoding