### PR TITLE
refactor(generate_reports): access _report_testsuite using self

### DIFF
--- a/xmlrunner/result.py
+++ b/xmlrunner/result.py
@@ -653,7 +653,7 @@ class _XMLTestResult(TextTestResult):
                 suite_name = '%s-%s' % (suite, test_runner.outsuffix)
 
             # Build the XML file
-            testsuite = _XMLTestResult._report_testsuite(
+            testsuite = self._report_testsuite(
                 suite_name, tests, doc, parentElement, self.properties
             )
 


### PR DESCRIPTION
This allows a subclass to override `_report_testsuite`.

We have a usecase where we want to add the cost of class level setup and teardown for our django project in the test suite timing. To do this cleanly we need to override `_report_testsuite`. This change should allow us to accomplish this without any hacky monkeypatching required.

<!--
Thank you for submitting a PR and your contribution!

Quick checklist

- [ ] Include unit tests when applicable
- [ ] Documentation and comments
- [ ] Reference existing issues, e.g. `see issue #123`, `closes #123`
- [ ] Reference existing pull requests, e.g. `supersedes PR #123`

See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

-->